### PR TITLE
Bypass pre/post-processing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 
 Development version (next release)
 - Re-organized test/client infrastructure to avoid code duplication
+- Bypasses pre/post-processing kernels if possible (in level-3 routines)
 - Added level-3 routines:
   * CHEMM/ZHEMM
   * SSYRK/DSYRK/CSYRK/ZSYRK

--- a/include/internal/routine.h
+++ b/include/internal/routine.h
@@ -84,17 +84,18 @@ class Routine {
   StatusCode TestVectorY(const size_t n, const Buffer &buffer, const size_t offset,
                          const size_t inc, const size_t data_size);
 
-  // Copies/transposes a matrix and padds/unpads it
+  // Copies/transposes a matrix and padds/unpads it with zeroes. This method is also able to write
+  // to symmetric and triangular matrices through optional arguments.
   StatusCode PadCopyTransposeMatrix(const size_t src_one, const size_t src_two,
                                     const size_t src_ld, const size_t src_offset,
                                     const Buffer &src,
                                     const size_t dest_one, const size_t dest_two,
                                     const size_t dest_ld, const size_t dest_offset,
                                     const Buffer &dest,
+                                    const Program &program, const bool do_pad,
                                     const bool do_transpose, const bool do_conjugate,
-                                    const bool pad, const bool upper, const bool lower,
-                                    const bool diagonal_imag_zero,
-                                    const Program &program);
+                                    const bool upper = false, const bool lower = false,
+                                    const bool diagonal_imag_zero = false);
   
   // Queries the cache and retrieve either a matching program or a boolean whether a match exists.
   // The first assumes that the program is available in the cache and will throw an exception

--- a/src/routine.cc
+++ b/src/routine.cc
@@ -202,17 +202,17 @@ StatusCode Routine::TestVectorY(const size_t n, const Buffer &buffer, const size
 
 // =================================================================================================
 
-// Copies a matrix and pads it with zeros
+// Copies or transposes a matrix and pads/unpads it with zeros
 StatusCode Routine::PadCopyTransposeMatrix(const size_t src_one, const size_t src_two,
                                            const size_t src_ld, const size_t src_offset,
                                            const Buffer &src,
                                            const size_t dest_one, const size_t dest_two,
                                            const size_t dest_ld, const size_t dest_offset,
                                            const Buffer &dest,
+                                           const Program &program, const bool do_pad,
                                            const bool do_transpose, const bool do_conjugate,
-                                           const bool pad, const bool upper, const bool lower,
-                                           const bool diagonal_imag_zero,
-                                           const Program &program) {
+                                           const bool upper, const bool lower,
+                                           const bool diagonal_imag_zero) {
 
   // Determines whether or not the fast-version could potentially be used
   auto use_fast_kernel = (src_offset == 0) && (dest_offset == 0) && (do_conjugate == false) &&
@@ -230,7 +230,7 @@ StatusCode Routine::PadCopyTransposeMatrix(const size_t src_one, const size_t sr
     }
     else {
       use_fast_kernel = false;
-      kernel_name = (pad) ? "PadTransposeMatrix" : "UnPadTransposeMatrix";
+      kernel_name = (do_pad) ? "PadTransposeMatrix" : "UnPadTransposeMatrix";
     }
   }
   else {
@@ -242,7 +242,7 @@ StatusCode Routine::PadCopyTransposeMatrix(const size_t src_one, const size_t sr
     }
     else {
       use_fast_kernel = false;
-      kernel_name = (pad) ? "PadMatrix" : "UnPadMatrix";
+      kernel_name = (do_pad) ? "PadMatrix" : "UnPadMatrix";
     }
   }
 
@@ -267,7 +267,7 @@ StatusCode Routine::PadCopyTransposeMatrix(const size_t src_one, const size_t sr
       kernel.SetArgument(7, static_cast<int>(dest_ld));
       kernel.SetArgument(8, static_cast<int>(dest_offset));
       kernel.SetArgument(9, dest());
-      if (pad) {
+      if (do_pad) {
         kernel.SetArgument(10, static_cast<int>(do_conjugate));
       }
       else {

--- a/src/routines/level3/xgemm.cc
+++ b/src/routines/level3/xgemm.cc
@@ -108,18 +108,18 @@ StatusCode Xgemm<T>::DoGemm(const Layout layout,
     // them up until they reach a certain multiple of size (kernel parameter dependent).
     status = PadCopyTransposeMatrix(a_one, a_two, a_ld, a_offset, a_buffer,
                                     m_ceiled, k_ceiled, m_ceiled, 0, temp_a,
-                                    a_do_transpose, a_conjugate, true, false, false, false, program);
+                                    program, true, a_do_transpose, a_conjugate);
     if (ErrorIn(status)) { return status; }
     status = PadCopyTransposeMatrix(b_one, b_two, b_ld, b_offset, b_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_b,
-                                    b_do_transpose, b_conjugate, true, false, false, false, program);
+                                    program, true, b_do_transpose, b_conjugate);
     if (ErrorIn(status)) { return status; }
 
     // Only necessary for matrix C if it used both as input and output
     if (beta != static_cast<T>(0)) {
       status = PadCopyTransposeMatrix(c_one, c_two, c_ld, c_offset, c_buffer,
                                       m_ceiled, n_ceiled, m_ceiled, 0, temp_c,
-                                      c_do_transpose, false, true, false, false, false, program);
+                                      program, true, c_do_transpose, false);
       if (ErrorIn(status)) { return status; }
     }
 
@@ -151,7 +151,7 @@ StatusCode Xgemm<T>::DoGemm(const Layout layout,
       // Runs the post-processing kernel
       status = PadCopyTransposeMatrix(m_ceiled, n_ceiled, m_ceiled, 0, temp_c,
                                       c_one, c_two, c_ld, c_offset, c_buffer,
-                                      c_do_transpose, false, false, false, false, false, program);
+                                      program, false, c_do_transpose, false);
       if (ErrorIn(status)) { return status; }
 
       // Successfully finished the computation

--- a/src/routines/level3/xher2k.cc
+++ b/src/routines/level3/xher2k.cc
@@ -96,25 +96,25 @@ StatusCode Xher2k<T,U>::DoHer2k(const Layout layout, const Triangle triangle, co
     // fill them up until they reach a certain multiple of size (kernel parameter dependent).
     status = PadCopyTransposeMatrix(ab_one, ab_two, a_ld, a_offset, a_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_a1,
-                                    ab_rotated, ab_conjugate, true, false, false, false, program);
+                                    program, true, ab_rotated, ab_conjugate);
     if (ErrorIn(status)) { return status; }
     status = PadCopyTransposeMatrix(ab_one, ab_two, a_ld, a_offset, a_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_a2,
-                                    ab_rotated, !ab_conjugate, true, false, false, false, program);
+                                    program, true, ab_rotated, !ab_conjugate);
     if (ErrorIn(status)) { return status; }
     status = PadCopyTransposeMatrix(ab_one, ab_two, b_ld, b_offset, b_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_b1,
-                                    ab_rotated, ab_conjugate, true, false, false, false, program);
+                                    program, true, ab_rotated, ab_conjugate);
     status = PadCopyTransposeMatrix(ab_one, ab_two, b_ld, b_offset, b_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_b2,
-                                    ab_rotated, !ab_conjugate, true, false, false, false, program);
+                                    program, true, ab_rotated, !ab_conjugate);
     if (ErrorIn(status)) { return status; }
 
     // Furthermore, also creates a (possibly padded) copy of matrix C, since it is not allowed to
     // modify the other triangle.
     status = PadCopyTransposeMatrix(n, n, c_ld, c_offset, c_buffer,
                                     n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
-                                    c_rotated, false, true, false, false, false, program);
+                                    program, true, c_rotated, false);
     if (ErrorIn(status)) { return status; }
 
     // Retrieves the XgemmUpper or XgemmLower kernel from the compiled binary
@@ -159,7 +159,7 @@ StatusCode Xher2k<T,U>::DoHer2k(const Layout layout, const Triangle triangle, co
       auto lower = (triangle == Triangle::kLower);
       status = PadCopyTransposeMatrix(n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
                                       n, n, c_ld, c_offset, c_buffer,
-                                      c_rotated, false, false, upper, lower, true, program);
+                                      program, false, c_rotated, false, upper, lower, true);
       if (ErrorIn(status)) { return status; }
 
       // Successfully finished the computation

--- a/src/routines/level3/xherk.cc
+++ b/src/routines/level3/xherk.cc
@@ -92,18 +92,18 @@ StatusCode Xherk<T,U>::DoHerk(const Layout layout, const Triangle triangle, cons
     // creates two copies: 
     status = PadCopyTransposeMatrix(a_one, a_two, a_ld, a_offset, a_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_a,
-                                    a_rotated, a_conjugate, true, false, false, false, program);
+                                    program, true, a_rotated, a_conjugate);
     if (ErrorIn(status)) { return status; }
     status = PadCopyTransposeMatrix(a_one, a_two, a_ld, a_offset, a_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_b,
-                                    a_rotated, b_conjugate, true, false, false, false, program);
+                                    program, true, a_rotated, b_conjugate);
     if (ErrorIn(status)) { return status; }
 
     // Furthermore, also creates a (possibly padded) copy of matrix C, since it is not allowed to
     // modify the other triangle.
     status = PadCopyTransposeMatrix(n, n, c_ld, c_offset, c_buffer,
                                     n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
-                                    c_rotated, false, true, false, false, false, program);
+                                    program, true, c_rotated, false);
     if (ErrorIn(status)) { return status; }
 
     // Retrieves the XgemmUpper or XgemmLower kernel from the compiled binary
@@ -137,7 +137,7 @@ StatusCode Xherk<T,U>::DoHerk(const Layout layout, const Triangle triangle, cons
       auto lower = (triangle == Triangle::kLower);
       status = PadCopyTransposeMatrix(n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
                                       n, n, c_ld, c_offset, c_buffer,
-                                      c_rotated, false, false, upper, lower, true, program);
+                                      program, false, c_rotated, false, upper, lower, true);
       if (ErrorIn(status)) { return status; }
 
       // Successfully finished the computation

--- a/src/routines/level3/xherk.cc
+++ b/src/routines/level3/xherk.cc
@@ -78,31 +78,43 @@ StatusCode Xherk<T,U>::DoHerk(const Layout layout, const Triangle triangle, cons
   // Decides which kernel to run: the upper-triangular or lower-triangular version
   auto kernel_name = (triangle == Triangle::kUpper) ? "XgemmUpper" : "XgemmLower";
 
-  // Allocates space on the device for padded and/or transposed input and output matrices.
+  // The padded/transposed input/output matrices: if memory allocation fails, throw an exception
   try {
-    auto temp_a = Buffer(context_, CL_MEM_READ_WRITE, k_ceiled*n_ceiled*sizeof(T));
-    auto temp_b = Buffer(context_, CL_MEM_READ_WRITE, k_ceiled*n_ceiled*sizeof(T));
-    auto temp_c = Buffer(context_, CL_MEM_READ_WRITE, n_ceiled*n_ceiled*sizeof(T));
 
     // Loads the program from the database
     auto& program = GetProgramFromCache();
 
-    // Runs the pre-processing kernel. This transposes the matrix A, but also pads zeros to
-    // fill it up until it reaches a certain multiple of size (kernel parameter dependent). It
-    // creates two copies: 
-    status = PadCopyTransposeMatrix(a_one, a_two, a_ld, a_offset, a_buffer,
-                                    n_ceiled, k_ceiled, n_ceiled, 0, temp_a,
-                                    program, true, a_rotated, a_conjugate);
-    if (ErrorIn(status)) { return status; }
-    status = PadCopyTransposeMatrix(a_one, a_two, a_ld, a_offset, a_buffer,
-                                    n_ceiled, k_ceiled, n_ceiled, 0, temp_b,
-                                    program, true, a_rotated, b_conjugate);
-    if (ErrorIn(status)) { return status; }
+    // Determines whether or not temporary matrices are needed
+    auto a_no_temp = a_one == n_ceiled && a_two == k_ceiled && a_ld == n_ceiled && a_offset == 0 &&
+                     a_rotated == false && a_conjugate == false;
+    auto b_no_temp = a_one == n_ceiled && a_two == k_ceiled && a_ld == n_ceiled && a_offset == 0 &&
+                     a_rotated == false && b_conjugate == false;
+
+    // Creates the temporary matrices
+    auto a_temp = (a_no_temp) ? a_buffer : Buffer(context_, CL_MEM_READ_WRITE, k_ceiled*n_ceiled*sizeof(T));
+    auto b_temp = (b_no_temp) ? a_buffer : Buffer(context_, CL_MEM_READ_WRITE, k_ceiled*n_ceiled*sizeof(T));
+    auto c_temp = Buffer(context_, CL_MEM_READ_WRITE, n_ceiled*n_ceiled*sizeof(T));
+
+    // Runs the pre-processing kernel for matrix A. This transposes the matrix, but also pads zeros
+    // to fill it up until it reaches a certain multiple of size (kernel parameter dependent). In
+    // case nothing has to be done, these kernels can be skipped. Two copies are created.
+    if (!a_no_temp) {
+      status = PadCopyTransposeMatrix(a_one, a_two, a_ld, a_offset, a_buffer,
+                                      n_ceiled, k_ceiled, n_ceiled, 0, a_temp,
+                                      program, true, a_rotated, a_conjugate);
+      if (ErrorIn(status)) { return status; }
+    }
+    if (!b_no_temp) {
+      status = PadCopyTransposeMatrix(a_one, a_two, a_ld, a_offset, a_buffer,
+                                      n_ceiled, k_ceiled, n_ceiled, 0, b_temp,
+                                      program, true, a_rotated, b_conjugate);
+      if (ErrorIn(status)) { return status; }
+    }
 
     // Furthermore, also creates a (possibly padded) copy of matrix C, since it is not allowed to
     // modify the other triangle.
     status = PadCopyTransposeMatrix(n, n, c_ld, c_offset, c_buffer,
-                                    n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
+                                    n_ceiled, n_ceiled, n_ceiled, 0, c_temp,
                                     program, true, c_rotated, false);
     if (ErrorIn(status)) { return status; }
 
@@ -117,9 +129,9 @@ StatusCode Xherk<T,U>::DoHerk(const Layout layout, const Triangle triangle, cons
       kernel.SetArgument(1, static_cast<int>(k_ceiled));
       kernel.SetArgument(2, complex_alpha);
       kernel.SetArgument(3, complex_beta);
-      kernel.SetArgument(4, temp_a());
-      kernel.SetArgument(5, temp_b());
-      kernel.SetArgument(6, temp_c());
+      kernel.SetArgument(4, a_temp());
+      kernel.SetArgument(5, b_temp());
+      kernel.SetArgument(6, c_temp());
 
       // Computes the global and local thread sizes
       auto global = std::vector<size_t>{
@@ -135,7 +147,7 @@ StatusCode Xherk<T,U>::DoHerk(const Layout layout, const Triangle triangle, cons
       // Runs the post-processing kernel
       auto upper = (triangle == Triangle::kUpper);
       auto lower = (triangle == Triangle::kLower);
-      status = PadCopyTransposeMatrix(n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
+      status = PadCopyTransposeMatrix(n_ceiled, n_ceiled, n_ceiled, 0, c_temp,
                                       n, n, c_ld, c_offset, c_buffer,
                                       program, false, c_rotated, false, upper, lower, true);
       if (ErrorIn(status)) { return status; }

--- a/src/routines/level3/xsyr2k.cc
+++ b/src/routines/level3/xsyr2k.cc
@@ -92,18 +92,18 @@ StatusCode Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, cons
     // fill them up until they reach a certain multiple of size (kernel parameter dependent).
     status = PadCopyTransposeMatrix(ab_one, ab_two, a_ld, a_offset, a_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_a,
-                                    ab_rotated, false, true, false, false, false, program);
+                                    program, true, ab_rotated, false);
     if (ErrorIn(status)) { return status; }
     status = PadCopyTransposeMatrix(ab_one, ab_two, b_ld, b_offset, b_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_b,
-                                    ab_rotated, false, true, false, false, false, program);
+                                    program, true, ab_rotated, false);
     if (ErrorIn(status)) { return status; }
 
     // Furthermore, also creates a (possibly padded) copy of matrix C, since it is not allowed to
     // modify the other triangle.
     status = PadCopyTransposeMatrix(n, n, c_ld, c_offset, c_buffer,
                                     n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
-                                    c_rotated, false, true, false, false, false, program);
+                                    program, true, c_rotated, false);
     if (ErrorIn(status)) { return status; }
 
     // Retrieves the XgemmUpper or XgemmLower kernel from the compiled binary
@@ -145,7 +145,7 @@ StatusCode Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, cons
       auto lower = (triangle == Triangle::kLower);
       status = PadCopyTransposeMatrix(n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
                                       n, n, c_ld, c_offset, c_buffer,
-                                      c_rotated, false, false, upper, lower, false, program);
+                                      program, false, c_rotated, false, upper, lower, false);
       if (ErrorIn(status)) { return status; }
 
       // Successfully finished the computation

--- a/src/routines/level3/xsyrk.cc
+++ b/src/routines/level3/xsyrk.cc
@@ -87,14 +87,14 @@ StatusCode Xsyrk<T>::DoSyrk(const Layout layout, const Triangle triangle, const 
     // fill it up until it reaches a certain multiple of size (kernel parameter dependent).
     status = PadCopyTransposeMatrix(a_one, a_two, a_ld, a_offset, a_buffer,
                                     n_ceiled, k_ceiled, n_ceiled, 0, temp_a,
-                                    a_rotated, false, true, false, false, false, program);
+                                    program, true, a_rotated, false);
     if (ErrorIn(status)) { return status; }
 
     // Furthermore, also creates a (possibly padded) copy of matrix C, since it is not allowed to
     // modify the other triangle.
     status = PadCopyTransposeMatrix(n, n, c_ld, c_offset, c_buffer,
                                     n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
-                                    c_rotated, false, true, false, false, false, program);
+                                    program, true, c_rotated, false);
     if (ErrorIn(status)) { return status; }
 
     // Retrieves the XgemmUpper or XgemmLower kernel from the compiled binary
@@ -126,7 +126,7 @@ StatusCode Xsyrk<T>::DoSyrk(const Layout layout, const Triangle triangle, const 
       auto lower = (triangle == Triangle::kLower);
       status = PadCopyTransposeMatrix(n_ceiled, n_ceiled, n_ceiled, 0, temp_c,
                                       n, n, c_ld, c_offset, c_buffer,
-                                      c_rotated, false, false, upper, lower, false, program);
+                                      program, false, c_rotated, false, upper, lower, false);
       if (ErrorIn(status)) { return status; }
 
       // Successfully finished the computation

--- a/test/performance/graphs/xgemm.r
+++ b/test/performance/graphs/xgemm.r
@@ -35,10 +35,10 @@ test_names <- list(
 
 # Defines the test-cases
 test_values <- list(
-  list(c(128, 128, 128, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(129, 129, 129, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(512, 512, 512, 0, 0, 0, 16, 1, num_runs, precision)),
-  list(c(2048, 2048, 2048, 0, 0, 0, 16, 1, num_runs, precision)),
+  list(c( 128,  128,  128, 1, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 129,  129,  129, 1, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 512,  512,  512, 1, 0, 0, 16, 1, num_runs, precision)),
+  list(c(2048, 2048, 2048, 1, 0, 0, 16, 1, num_runs, precision)),
   list(
     c(1024, 1024, 1024, 0, 0, 0, 1, 0, num_runs, precision),
     c(1024, 1024, 1024, 0, 0, 1, 1, 0, num_runs, precision),
@@ -50,17 +50,17 @@ test_values <- list(
     c(1024, 1024, 1024, 1, 1, 1, 1, 0, num_runs, precision)
   ),
   list(
-    c(8, 8, 8, 0, 0, 0, 1, 0, num_runs, precision),
-    c(16, 16, 16, 0, 0, 0, 1, 0, num_runs, precision),
-    c(32, 32, 32, 0, 0, 0, 1, 0, num_runs, precision),
-    c(64, 64, 64, 0, 0, 0, 1, 0, num_runs, precision),
-    c(128, 128, 128, 0, 0, 0, 1, 0, num_runs, precision),
-    c(256, 256, 256, 0, 0, 0, 1, 0, num_runs, precision),
-    c(512, 512, 512, 0, 0, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 1024, 0, 0, 0, 1, 0, num_runs, precision),
-    c(2048, 2048, 2048, 0, 0, 0, 1, 0, num_runs, precision),
-    c(4096, 4096, 4096, 0, 0, 0, 1, 0, num_runs, precision),
-    c(8192, 8192, 8192, 0, 0, 0, 1, 0, num_runs, precision)
+    c(   8,    8,    8, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  16,   16,   16, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  32,   32,   32, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  64,   64,   64, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 128,  128,  128, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 256,  256,  256, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 512,  512,  512, 1, 0, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1024, 1, 0, 0, 1, 0, num_runs, precision),
+    c(2048, 2048, 2048, 1, 0, 0, 1, 0, num_runs, precision),
+    c(4096, 4096, 4096, 1, 0, 0, 1, 0, num_runs, precision),
+    c(8192, 8192, 8192, 1, 0, 0, 1, 0, num_runs, precision)
   )
 )
 

--- a/test/performance/graphs/xsymm.r
+++ b/test/performance/graphs/xsymm.r
@@ -35,10 +35,10 @@ test_names <- list(
 
 # Defines the test-cases
 test_values <- list(
-  list(c(128, 128, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(129, 129, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(512, 512, 0, 0, 0, 16, 1, num_runs, precision)),
-  list(c(2048, 2048, 0, 0, 0, 16, 1, num_runs, precision)),
+  list(c( 128,  128, 1, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 129,  129, 1, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 512,  512, 1, 0, 0, 16, 1, num_runs, precision)),
+  list(c(2048, 2048, 1, 0, 0, 16, 1, num_runs, precision)),
   list(
     c(1024, 1024, 0, 0, 0, 1, 0, num_runs, precision),
     c(1024, 1024, 0, 0, 1, 1, 0, num_runs, precision),
@@ -50,17 +50,17 @@ test_values <- list(
     c(1024, 1024, 1, 1, 1, 1, 0, num_runs, precision)
   ),
   list(
-    c(8, 8, 0, 0, 0, 1, 0, num_runs, precision),
-    c(16, 16, 0, 0, 0, 1, 0, num_runs, precision),
-    c(32, 32, 0, 0, 0, 1, 0, num_runs, precision),
-    c(64, 64, 0, 0, 0, 1, 0, num_runs, precision),
-    c(128, 128, 0, 0, 0, 1, 0, num_runs, precision),
-    c(256, 256, 0, 0, 0, 1, 0, num_runs, precision),
-    c(512, 512, 0, 0, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 0, 1, 0, num_runs, precision),
-    c(2048, 2048, 0, 0, 0, 1, 0, num_runs, precision),
-    c(4096, 4096, 0, 0, 0, 1, 0, num_runs, precision),
-    c(8192, 8192, 0, 0, 0, 1, 0, num_runs, precision)
+    c(   8,    8, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  16,   16, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  32,   32, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  64,   64, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 128,  128, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 256,  256, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 512,  512, 1, 0, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 0, 1, 0, num_runs, precision),
+    c(2048, 2048, 1, 0, 0, 1, 0, num_runs, precision),
+    c(4096, 4096, 1, 0, 0, 1, 0, num_runs, precision),
+    c(8192, 8192, 1, 0, 0, 1, 0, num_runs, precision)
   )
 )
 

--- a/test/performance/graphs/xsyr2k.r
+++ b/test/performance/graphs/xsyr2k.r
@@ -35,10 +35,10 @@ test_names <- list(
 
 # Defines the test-cases
 test_values <- list(
-  list(c(128, 128, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(129, 129, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(512, 512, 0, 0, 0, 16, 1, num_runs, precision)),
-  list(c(1536, 1536, 0, 0, 0, 16, 1, num_runs, precision)),
+  list(c( 128,  128, 1, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 129,  129, 1, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 512,  512, 1, 0, 0, 16, 1, num_runs, precision)),
+  list(c(1536, 1536, 1, 0, 0, 16, 1, num_runs, precision)),
   list(
     c(1024, 1024, 0, 0, 0, 1, 0, num_runs, precision),
     c(1024, 1024, 0, 0, 1, 1, 0, num_runs, precision),
@@ -50,17 +50,17 @@ test_values <- list(
     c(1024, 1024, 1, 1, 1, 1, 0, num_runs, precision)
   ),
   list(
-    c(8, 8, 0, 0, 0, 1, 0, num_runs, precision),
-    c(16, 16, 0, 0, 0, 1, 0, num_runs, precision),
-    c(32, 32, 0, 0, 0, 1, 0, num_runs, precision),
-    c(64, 64, 0, 0, 0, 1, 0, num_runs, precision),
-    c(128, 128, 0, 0, 0, 1, 0, num_runs, precision),
-    c(256, 256, 0, 0, 0, 1, 0, num_runs, precision),
-    c(512, 512, 0, 0, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 0, 1, 0, num_runs, precision),
-    c(2048, 2048, 0, 0, 0, 1, 0, num_runs, precision),
-    c(4096, 4096, 0, 0, 0, 1, 0, num_runs, precision),
-    c(8192, 8192, 0, 0, 0, 1, 0, num_runs, precision)
+    c(   8,    8, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  16,   16, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  32,   32, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  64,   64, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 128,  128, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 256,  256, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 512,  512, 1, 0, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 0, 1, 0, num_runs, precision),
+    c(2048, 2048, 1, 0, 0, 1, 0, num_runs, precision),
+    c(4096, 4096, 1, 0, 0, 1, 0, num_runs, precision),
+    c(8192, 8192, 1, 0, 0, 1, 0, num_runs, precision)
   )
 )
 

--- a/test/performance/graphs/xsyrk.r
+++ b/test/performance/graphs/xsyrk.r
@@ -35,10 +35,10 @@ test_names <- list(
 
 # Defines the test-cases
 test_values <- list(
-  list(c(128, 128, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(129, 129, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(512, 512, 0, 0, 0, 16, 1, num_runs, precision)),
-  list(c(2048, 2048, 0, 0, 0, 16, 1, num_runs, precision)),
+  list(c( 128,  128, 1, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 129,  129, 1, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 512,  512, 1, 0, 0, 16, 1, num_runs, precision)),
+  list(c(2048, 2048, 1, 0, 0, 16, 1, num_runs, precision)),
   list(
     c(1024, 1024, 0, 0, 0, 1, 0, num_runs, precision),
     c(1024, 1024, 0, 0, 1, 1, 0, num_runs, precision),
@@ -50,17 +50,17 @@ test_values <- list(
     c(1024, 1024, 1, 1, 1, 1, 0, num_runs, precision)
   ),
   list(
-    c(8, 8, 0, 0, 0, 1, 0, num_runs, precision),
-    c(16, 16, 0, 0, 0, 1, 0, num_runs, precision),
-    c(32, 32, 0, 0, 0, 1, 0, num_runs, precision),
-    c(64, 64, 0, 0, 0, 1, 0, num_runs, precision),
-    c(128, 128, 0, 0, 0, 1, 0, num_runs, precision),
-    c(256, 256, 0, 0, 0, 1, 0, num_runs, precision),
-    c(512, 512, 0, 0, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 0, 1, 0, num_runs, precision),
-    c(2048, 2048, 0, 0, 0, 1, 0, num_runs, precision),
-    c(4096, 4096, 0, 0, 0, 1, 0, num_runs, precision),
-    c(8192, 8192, 0, 0, 0, 1, 0, num_runs, precision)
+    c(   8,    8, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  16,   16, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  32,   32, 1, 0, 0, 1, 0, num_runs, precision),
+    c(  64,   64, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 128,  128, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 256,  256, 1, 0, 0, 1, 0, num_runs, precision),
+    c( 512,  512, 1, 0, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 0, 1, 0, num_runs, precision),
+    c(2048, 2048, 1, 0, 0, 1, 0, num_runs, precision),
+    c(4096, 4096, 1, 0, 0, 1, 0, num_runs, precision),
+    c(8192, 8192, 1, 0, 0, 1, 0, num_runs, precision)
   )
 )
 

--- a/test/performance/graphs/xtrmm.r
+++ b/test/performance/graphs/xtrmm.r
@@ -35,10 +35,10 @@ test_names <- list(
 
 # Defines the test-cases
 test_values <- list(
-  list(c(128, 128, 0, 0, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(129, 129, 0, 0, 0, 0, 0, 16, 128, num_runs, precision)),
-  list(c(512, 512, 0, 0, 0, 0, 0, 16, 1, num_runs, precision)),
-  list(c(2048, 2048, 0, 0, 0, 0, 0, 16, 1, num_runs, precision)),
+  list(c( 128,  128, 1, 0, 0, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 129,  129, 1, 0, 0, 0, 0, 16, 128, num_runs, precision)),
+  list(c( 512,  512, 1, 0, 0, 0, 0, 16, 1, num_runs, precision)),
+  list(c(2048, 2048, 1, 0, 0, 0, 0, 16, 1, num_runs, precision)),
   list(
     c(1024, 1024, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
     c(1024, 1024, 0, 0, 0, 0, 1, 1, 0, num_runs, precision),
@@ -58,14 +58,14 @@ test_values <- list(
     c(1024, 1024, 0, 1, 1, 1, 0, 1, 0, num_runs, precision),
     c(1024, 1024, 0, 1, 1, 1, 1, 1, 0, num_runs, precision),
 
-    c(1024, 1024, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 0, 0, 1, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 0, 1, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 0, 1, 1, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 1, 0, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 1, 0, 1, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 1, 1, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 1, 1, 1, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 0, 0, 1, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 0, 1, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 0, 1, 1, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 1, 0, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 1, 0, 1, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 1, 1, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 1, 1, 1, 1, 0, num_runs, precision),
 
     c(1024, 1024, 1, 1, 0, 0, 0, 1, 0, num_runs, precision),
     c(1024, 1024, 1, 1, 0, 0, 1, 1, 0, num_runs, precision),
@@ -77,17 +77,17 @@ test_values <- list(
     c(1024, 1024, 1, 1, 1, 1, 1, 1, 0, num_runs, precision)
   ),
   list(
-    c(8, 8, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(16, 16, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(32, 32, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(64, 64, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(128, 128, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(256, 256, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(512, 512, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(1024, 1024, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(2048, 2048, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(4096, 4096, 0, 0, 0, 0, 0, 1, 0, num_runs, precision),
-    c(8192, 8192, 0, 0, 0, 0, 0, 1, 0, num_runs, precision)
+    c(   8,    8, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c(  16,   16, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c(  32,   32, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c(  64,   64, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c( 128,  128, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c( 256,  256, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c( 512,  512, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c(1024, 1024, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c(2048, 2048, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c(4096, 4096, 1, 0, 0, 0, 0, 1, 0, num_runs, precision),
+    c(8192, 8192, 1, 0, 0, 0, 0, 1, 0, num_runs, precision)
   )
 )
 


### PR DESCRIPTION
Added the possibility to bypass pre-processing and/or post-processing kernels for level-3 routines. In case the bypass is used (e.g. no transpose is needed, no padding is needed), the temporary buffer is also not allocated. This improves performance and saves memory in specific scenarios: certain input sizes (multiple of tile-size) and certain transpose/layout configurations.

Also changed the default layout to column-major for the performance graphs and made the 3 triangular-related arguments to the pre/post-processing method optional.