### PR TITLE
Now using the new Claduc C++11 OpenCL header

### DIFF
--- a/include/internal/database.h
+++ b/include/internal/database.h
@@ -39,7 +39,7 @@ class Database {
     const Parameters parameters;
   };
   struct DatabaseVendor {
-    const cl_device_type type;
+    const std::string type;
     const std::string name;
     const std::vector<DatabaseDevice> devices;
   };
@@ -49,8 +49,21 @@ class Database {
     const std::vector<DatabaseVendor> vendors;
   };
 
-  // The default vendor or device
-  static constexpr auto kDefault = "Default";
+  // The OpenCL device types
+  static constexpr auto kDeviceTypeCPU = "CPU";
+  static constexpr auto kDeviceTypeGPU = "GPU";
+  static constexpr auto kDeviceTypeAccelerator = "accelerator";
+  static constexpr auto kDeviceTypeAll = "default";
+
+  // The OpenCL device vendors
+  static constexpr auto kDeviceVendorNVIDIA = "NVIDIA Corporation";
+  static constexpr auto kDeviceVendorAMD = "Advanced Micro Devices, Inc.";
+  static constexpr auto kDeviceVendorIntel = "Intel";
+  static constexpr auto kDeviceVendorAll = "default";
+
+  // The OpenCL device names
+  static constexpr auto kDefaultDevice = "default";
+
 
   // The database consists of separate database entries, stored together in a vector
   static const DatabaseEntry XaxpySingle, XaxpyDouble, XaxpyComplexSingle, XaxpyComplexDouble;
@@ -63,7 +76,7 @@ class Database {
   static const std::vector<DatabaseEntry> database;
 
   // The constructor
-  explicit Database(const CommandQueue &queue, const std::vector<std::string> &routines,
+  explicit Database(const Queue &queue, const std::vector<std::string> &routines,
                     const Precision precision);
 
   // Accessor of values by key
@@ -73,12 +86,9 @@ class Database {
   std::string GetDefines() const;
 
  private:
-  Parameters Search(const std::string &this_kernel, const cl_device_type this_type,
+  Parameters Search(const std::string &this_kernel, const std::string &this_type,
                     const std::string &this_vendor, const std::string &this_device,
                     const Precision this_precision) const;
-
-  // Tests equality between a database-vendor string and an OpenCL vendor string
-  bool VendorEqual(const std::string &db_vendor, const std::string &cl_vendor) const;
 
   // Found parameters suitable for this device/kernel
   Parameters parameters_;

--- a/include/internal/database/copy.h
+++ b/include/internal/database/copy.h
@@ -17,25 +17,25 @@ namespace clblast {
 const Database::DatabaseEntry Database::CopySingle = {
   "Copy", Precision::kSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"COPY_DIMX",32}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",2} } },
         { "Tesla K20m",       { {"COPY_DIMX",8}, {"COPY_DIMY",16}, {"COPY_WPT",2}, {"COPY_VW",4} } },
         { "Tesla K40m",       { {"COPY_DIMX",16}, {"COPY_DIMY",16}, {"COPY_WPT",4}, {"COPY_VW",4} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"COPY_DIMX",16}, {"COPY_DIMY",8}, {"COPY_WPT",4}, {"COPY_VW",2} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"COPY_DIMX",32}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",4} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
       }
     },
   }
@@ -46,24 +46,24 @@ const Database::DatabaseEntry Database::CopySingle = {
 const Database::DatabaseEntry Database::CopyDouble = {
   "Copy", Precision::kDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"COPY_DIMX",16}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
         { "Tesla K20m",       { {"COPY_DIMX",16}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",2} } },
         { "Tesla K40m",       { {"COPY_DIMX",32}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",2} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"COPY_DIMX",16}, {"COPY_DIMY",8}, {"COPY_WPT",2}, {"COPY_VW",4} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
       }
     },
   }
@@ -74,25 +74,25 @@ const Database::DatabaseEntry Database::CopyDouble = {
 const Database::DatabaseEntry Database::CopyComplexSingle = {
   "Copy", Precision::kComplexSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"COPY_DIMX",16}, {"COPY_DIMY",16}, {"COPY_WPT",1}, {"COPY_VW",1} } },
         { "Tesla K20m",       { {"COPY_DIMX",32}, {"COPY_DIMY",8}, {"COPY_WPT",2}, {"COPY_VW",1} } },
         { "Tesla K40m",       { {"COPY_DIMX",32}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"COPY_DIMX",32}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"COPY_DIMX",32}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
       }
     },
   }
@@ -103,24 +103,24 @@ const Database::DatabaseEntry Database::CopyComplexSingle = {
 const Database::DatabaseEntry Database::CopyComplexDouble = {
   "Copy", Precision::kComplexDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"COPY_DIMX",16}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
         { "Tesla K20m",       { {"COPY_DIMX",8}, {"COPY_DIMY",32}, {"COPY_WPT",1}, {"COPY_VW",1} } },
         { "Tesla K40m",       { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"COPY_DIMX",8}, {"COPY_DIMY",32}, {"COPY_WPT",4}, {"COPY_VW",2} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"COPY_DIMX",8}, {"COPY_DIMY",8}, {"COPY_WPT",1}, {"COPY_VW",1} } },
       }
     },
   }

--- a/include/internal/database/pad.h
+++ b/include/internal/database/pad.h
@@ -17,25 +17,25 @@ namespace clblast {
 const Database::DatabaseEntry Database::PadSingle = {
   "Pad", Precision::kSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"PAD_DIMX",32}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",4} } },
         { "Tesla K20m",       { {"PAD_DIMX",16}, {"PAD_DIMY",32}, {"PAD_WPTX",2}, {"PAD_WPTY",1} } },
         { "Tesla K40m",       { {"PAD_DIMX",32}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",2} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"PAD_DIMX",32}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",2} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"PAD_DIMX",32}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",2} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
   }
@@ -46,24 +46,24 @@ const Database::DatabaseEntry Database::PadSingle = {
 const Database::DatabaseEntry Database::PadDouble = {
   "Pad", Precision::kDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"PAD_DIMX",16}, {"PAD_DIMY",16}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
         { "Tesla K20m",       { {"PAD_DIMX",16}, {"PAD_DIMY",16}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
         { "Tesla K40m",       { {"PAD_DIMX",16}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",2} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
   }
@@ -74,25 +74,25 @@ const Database::DatabaseEntry Database::PadDouble = {
 const Database::DatabaseEntry Database::PadComplexSingle = {
   "Pad", Precision::kComplexSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"PAD_DIMX",16}, {"PAD_DIMY",16}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
         { "Tesla K20m",       { {"PAD_DIMX",16}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",2} } },
         { "Tesla K40m",       { {"PAD_DIMX",16}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"PAD_DIMX",32}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"PAD_DIMX",32}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
   }
@@ -103,24 +103,24 @@ const Database::DatabaseEntry Database::PadComplexSingle = {
 const Database::DatabaseEntry Database::PadComplexDouble = {
   "Pad", Precision::kComplexDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"PAD_DIMX",16}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
         { "Tesla K20m",       { {"PAD_DIMX",32}, {"PAD_DIMY",16}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
         { "Tesla K40m",       { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"PAD_DIMX",8}, {"PAD_DIMY",16}, {"PAD_WPTX",2}, {"PAD_WPTY",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"PAD_DIMX",8}, {"PAD_DIMY",8}, {"PAD_WPTX",1}, {"PAD_WPTY",1} } },
       }
     },
   }

--- a/include/internal/database/padtranspose.h
+++ b/include/internal/database/padtranspose.h
@@ -17,25 +17,25 @@ namespace clblast {
 const Database::DatabaseEntry Database::PadTraSingle = {
   "PadTranspose", Precision::kSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"PADTRA_TILE",16}, {"PADTRA_WPT",2}, {"PADTRA_PAD",1} } },
         { "Tesla K20m",       { {"PADTRA_TILE",16}, {"PADTRA_WPT",2}, {"PADTRA_PAD",1} } },
         { "Tesla K40m",       { {"PADTRA_TILE",32}, {"PADTRA_WPT",2}, {"PADTRA_PAD",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"PADTRA_TILE",16}, {"PADTRA_WPT",4}, {"PADTRA_PAD",0} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"PADTRA_TILE",16}, {"PADTRA_WPT",2}, {"PADTRA_PAD",0} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
       }
     },
   }
@@ -46,24 +46,24 @@ const Database::DatabaseEntry Database::PadTraSingle = {
 const Database::DatabaseEntry Database::PadTraDouble = {
   "PadTranspose", Precision::kDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",1} } },
         { "Tesla K20m",       { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",1} } },
         { "Tesla K40m",       { {"PADTRA_TILE",16}, {"PADTRA_WPT",2}, {"PADTRA_PAD",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"PADTRA_TILE",8}, {"PADTRA_WPT",4}, {"PADTRA_PAD",0} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
       }
     },
   }
@@ -74,25 +74,25 @@ const Database::DatabaseEntry Database::PadTraDouble = {
 const Database::DatabaseEntry Database::PadTraComplexSingle = {
   "PadTranspose", Precision::kComplexSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",1} } },
         { "Tesla K20m",       { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",1} } },
         { "Tesla K40m",       { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"PADTRA_TILE",16}, {"PADTRA_WPT",2}, {"PADTRA_PAD",0} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"PADTRA_TILE",16}, {"PADTRA_WPT",2}, {"PADTRA_PAD",0} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
       }
     },
   }
@@ -103,24 +103,24 @@ const Database::DatabaseEntry Database::PadTraComplexSingle = {
 const Database::DatabaseEntry Database::PadTraComplexDouble = {
   "PadTranspose", Precision::kComplexDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",1} } },
         { "Tesla K20m",       { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",1} } },
         { "Tesla K40m",       { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"PADTRA_TILE",8}, {"PADTRA_WPT",2}, {"PADTRA_PAD",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"PADTRA_TILE",16}, {"PADTRA_WPT",1}, {"PADTRA_PAD",0} } },
       }
     },
   }

--- a/include/internal/database/transpose.h
+++ b/include/internal/database/transpose.h
@@ -17,25 +17,25 @@ namespace clblast {
 const Database::DatabaseEntry Database::TraSingle = {
   "Transpose", Precision::kSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"TRA_DIM",16}, {"TRA_WPT",2}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
         { "Tesla K20m",       { {"TRA_DIM",16}, {"TRA_WPT",2}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
         { "Tesla K40m",       { {"TRA_DIM",16}, {"TRA_WPT",2}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"TRA_DIM",16}, {"TRA_WPT",4}, {"TRA_PAD",0}, {"TRA_SHUFFLE",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"TRA_DIM",8}, {"TRA_WPT",4}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
       }
     },
   }
@@ -46,24 +46,24 @@ const Database::DatabaseEntry Database::TraSingle = {
 const Database::DatabaseEntry Database::TraDouble = {
   "Transpose", Precision::kDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"TRA_DIM",8}, {"TRA_WPT",2}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
         { "Tesla K20m",       { {"TRA_DIM",16}, {"TRA_WPT",2}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
         { "Tesla K40m",       { {"TRA_DIM",16}, {"TRA_WPT",2}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"TRA_DIM",16}, {"TRA_WPT",2}, {"TRA_PAD",0}, {"TRA_SHUFFLE",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
       }
     },
   }
@@ -74,25 +74,25 @@ const Database::DatabaseEntry Database::TraDouble = {
 const Database::DatabaseEntry Database::TraComplexSingle = {
   "Transpose", Precision::kComplexSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
         { "Tesla K20m",       { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
         { "Tesla K40m",       { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"TRA_DIM",16}, {"TRA_WPT",2}, {"TRA_PAD",1}, {"TRA_SHUFFLE",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
       }
     },
   }
@@ -103,24 +103,24 @@ const Database::DatabaseEntry Database::TraComplexSingle = {
 const Database::DatabaseEntry Database::TraComplexDouble = {
   "Transpose", Precision::kComplexDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"TRA_DIM",8}, {"TRA_WPT",1}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
         { "Tesla K20m",       { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
         { "Tesla K40m",       { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",1}, {"TRA_SHUFFLE",0} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"TRA_DIM",16}, {"TRA_WPT",1}, {"TRA_PAD",0}, {"TRA_SHUFFLE",0} } },
       }
     },
   }

--- a/include/internal/database/xaxpy.h
+++ b/include/internal/database/xaxpy.h
@@ -17,25 +17,25 @@ namespace clblast {
 const Database::DatabaseEntry Database::XaxpySingle = {
   "Xaxpy", Precision::kSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"WGS",128}, {"WPT",1}, {"VW",2} } },
         { "Tesla K20m",       { {"WGS",128}, {"WPT",2}, {"VW",2} } },
         { "Tesla K40m",       { {"WGS",128}, {"WPT",1}, {"VW",4} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"WGS",64}, {"WPT",1}, {"VW",2} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"WGS",512}, {"WPT",1}, {"VW",1} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"WGS",128}, {"WPT",1}, {"VW",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"WGS",128}, {"WPT",1}, {"VW",1} } },
       }
     },
   }
@@ -46,24 +46,24 @@ const Database::DatabaseEntry Database::XaxpySingle = {
 const Database::DatabaseEntry Database::XaxpyDouble = {
   "Xaxpy", Precision::kDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"WGS",128}, {"WPT",1}, {"VW",1} } },
         { "Tesla K20m",       { {"WGS",512}, {"WPT",1}, {"VW",2} } },
         { "Tesla K40m",       { {"WGS",64}, {"WPT",1}, {"VW",2} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"WGS",256}, {"WPT",1}, {"VW",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"WGS",128}, {"WPT",1}, {"VW",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"WGS",128}, {"WPT",1}, {"VW",1} } },
       }
     },
   }
@@ -73,25 +73,25 @@ const Database::DatabaseEntry Database::XaxpyDouble = {
 const Database::DatabaseEntry Database::XaxpyComplexSingle = {
   "Xaxpy", Precision::kComplexSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"WGS",256}, {"WPT",1}, {"VW",1} } },
         { "Tesla K20m",       { {"WGS",128}, {"WPT",1}, {"VW",1} } },
         { "Tesla K40m",       { {"WGS",128}, {"WPT",2}, {"VW",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"WGS",64}, {"WPT",1}, {"VW",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"WGS",256}, {"WPT",1}, {"VW",1} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"WGS",128}, {"WPT",1}, {"VW",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"WGS",128}, {"WPT",1}, {"VW",1} } },
       }
     },
   }
@@ -102,24 +102,24 @@ const Database::DatabaseEntry Database::XaxpyComplexSingle = {
 const Database::DatabaseEntry Database::XaxpyComplexDouble = {
   "Xaxpy", Precision::kComplexDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"WGS",128}, {"WPT",2}, {"VW",1} } },
         { "Tesla K20m",       { {"WGS",256}, {"WPT",1}, {"VW",1} } },
         { "Tesla K40m",       { {"WGS",64}, {"WPT",2}, {"VW",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"WGS",64}, {"WPT",1}, {"VW",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"WGS",128}, {"WPT",1}, {"VW",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"WGS",128}, {"WPT",1}, {"VW",1} } },
       }
     },
   }

--- a/include/internal/database/xgemm.h
+++ b/include/internal/database/xgemm.h
@@ -17,26 +17,26 @@ namespace clblast {
 const Database::DatabaseEntry Database::XgemmSingle = {
   "Xgemm", Precision::kSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"MWG",128}, {"NWG",64}, {"KWG",32}, {"MDIMC",16}, {"NDIMC",16}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",2}, {"VWM",2}, {"VWN",2}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",1} } },
         { "Tesla K20m",       { {"MWG",128}, {"NWG",64}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",32}, {"KWI",2}, {"VWM",4}, {"VWN",1}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",1} } },
         { "Tesla K40m",       { {"MWG",128}, {"NWG",128}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",16}, {"MDIMA",32}, {"NDIMB",16}, {"KWI",8}, {"VWM",2}, {"VWN",1}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",1} } },
-        { kDefault,           { {"MWG",128}, {"NWG",64}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",16}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",2}, {"VWM",2}, {"VWN",1}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",1} } },
+        { kDefaultDevice,     { {"MWG",128}, {"NWG",64}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",16}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",2}, {"VWM",2}, {"VWN",1}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"MWG",128}, {"NWG",128}, {"KWG",32}, {"MDIMC",16}, {"NDIMC",16}, {"MDIMA",32}, {"NDIMB",8}, {"KWI",2}, {"VWM",4}, {"VWN",4}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"MWG",64}, {"NWG",64}, {"KWG",32}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",8}, {"KWI",8}, {"VWM",4}, {"VWN",4}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",0} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
       }
     },
   }
@@ -47,25 +47,25 @@ const Database::DatabaseEntry Database::XgemmSingle = {
 const Database::DatabaseEntry Database::XgemmDouble = {
   "Xgemm", Precision::kDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"MWG",32}, {"NWG",64}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",16}, {"MDIMA",16}, {"NDIMB",32}, {"KWI",2}, {"VWM",1}, {"VWN",2}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",1} } },
         { "Tesla K20m",       { {"MWG",64}, {"NWG",128}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",32}, {"MDIMA",32}, {"NDIMB",32}, {"KWI",8}, {"VWM",2}, {"VWN",4}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",1} } },
         { "Tesla K40m",       { {"MWG",64}, {"NWG",64}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",16}, {"MDIMA",16}, {"NDIMB",32}, {"KWI",2}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",1} } },
-        { kDefault,           { {"MWG",32}, {"NWG",64}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",16}, {"MDIMA",16}, {"NDIMB",32}, {"KWI",2}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",1} } },
+        { kDefaultDevice,     { {"MWG",32}, {"NWG",64}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",16}, {"MDIMA",16}, {"NDIMB",32}, {"KWI",2}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"MWG",128}, {"NWG",64}, {"KWG",16}, {"MDIMC",32}, {"NDIMC",8}, {"MDIMA",32}, {"NDIMB",16}, {"KWI",8}, {"VWM",1}, {"VWN",2}, {"STRM",1}, {"STRN",0}, {"SA",0}, {"SB",0} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
       }
     },
   }
@@ -76,26 +76,26 @@ const Database::DatabaseEntry Database::XgemmDouble = {
 const Database::DatabaseEntry Database::XgemmComplexSingle = {
   "Xgemm", Precision::kComplexSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"MWG",32}, {"NWG",64}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",2}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",1} } },
         { "Tesla K20m",       { {"MWG",32}, {"NWG",64}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",8}, {"MDIMA",8}, {"NDIMB",8}, {"KWI",8}, {"VWM",2}, {"VWN",2}, {"STRM",1}, {"STRN",0}, {"SA",1}, {"SB",0} } },
         { "Tesla K40m",       { {"MWG",32}, {"NWG",64}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",32}, {"MDIMA",32}, {"NDIMB",16}, {"KWI",8}, {"VWM",1}, {"VWN",1}, {"STRM",0}, {"STRN",1}, {"SA",1}, {"SB",1} } },
-        { kDefault,           { {"MWG",32}, {"NWG",64}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",2}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",1} } },
+        { kDefaultDevice,     { {"MWG",32}, {"NWG",64}, {"KWG",16}, {"MDIMC",16}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",2}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"MWG",16}, {"NWG",64}, {"KWG",32}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",8}, {"NDIMB",16}, {"KWI",2}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",0} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
       }
     },
   }
@@ -106,25 +106,25 @@ const Database::DatabaseEntry Database::XgemmComplexSingle = {
 const Database::DatabaseEntry Database::XgemmComplexDouble = {
   "Xgemm", Precision::kComplexDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"MWG",16}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",8}, {"KWI",2}, {"VWM",1}, {"VWN",4}, {"STRM",1}, {"STRN",0}, {"SA",0}, {"SB",0} } },
         { "Tesla K20m",       { {"MWG",16}, {"NWG",128}, {"KWG",32}, {"MDIMC",8}, {"NDIMC",32}, {"MDIMA",8}, {"NDIMB",32}, {"KWI",2}, {"VWM",1}, {"VWN",4}, {"STRM",1}, {"STRN",1}, {"SA",1}, {"SB",0} } },
         { "Tesla K40m",       { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",32}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",32}, {"KWI",8}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",1} } },
-        { kDefault,           { {"MWG",16}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",8}, {"KWI",2}, {"VWM",1}, {"VWN",4}, {"STRM",1}, {"STRN",0}, {"SA",0}, {"SB",0} } },
+        { kDefaultDevice,     { {"MWG",16}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",8}, {"KWI",2}, {"VWM",1}, {"VWN",4}, {"STRM",1}, {"STRN",0}, {"SA",0}, {"SB",0} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"MWG",128}, {"NWG",32}, {"KWG",16}, {"MDIMC",32}, {"NDIMC",8}, {"MDIMA",32}, {"NDIMB",16}, {"KWI",8}, {"VWM",2}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"MWG",32}, {"NWG",32}, {"KWG",16}, {"MDIMC",8}, {"NDIMC",8}, {"MDIMA",16}, {"NDIMB",16}, {"KWI",1}, {"VWM",1}, {"VWN",1}, {"STRM",1}, {"STRN",1}, {"SA",0}, {"SB",0} } },
       }
     },
   }

--- a/include/internal/database/xgemv.h
+++ b/include/internal/database/xgemv.h
@@ -17,25 +17,25 @@ namespace clblast {
 const Database::DatabaseEntry Database::XgemvSingle = {
   "Xgemv", Precision::kSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
         { "Tesla K20m",       { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
         { "Tesla K40m",       { {"WGS1",256}, {"WPT1",1}, {"WGS2",256}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",4} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"WGS1",256}, {"WPT1",2}, {"WGS2",64}, {"WPT2",4}, {"VW2",4}, {"WGS3",256}, {"WPT3",2}, {"VW3",8} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
   }
@@ -46,24 +46,24 @@ const Database::DatabaseEntry Database::XgemvSingle = {
 const Database::DatabaseEntry Database::XgemvDouble = {
   "Xgemv", Precision::kDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
         { "Tesla K20m",       { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
         { "Tesla K40m",       { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
   }
@@ -73,25 +73,25 @@ const Database::DatabaseEntry Database::XgemvDouble = {
 const Database::DatabaseEntry Database::XgemvComplexSingle = {
   "Xgemv", Precision::kComplexSingle, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
         { "Tesla K20m",       { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
         { "Tesla K40m",       { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
         { "Iris",             { {"WGS1",256}, {"WPT1",1}, {"WGS2",64}, {"WPT2",4}, {"VW2",2}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
   }
@@ -102,24 +102,24 @@ const Database::DatabaseEntry Database::XgemvComplexSingle = {
 const Database::DatabaseEntry Database::XgemvComplexDouble = {
   "Xgemv", Precision::kComplexDouble, {
     { // NVIDIA GPUs
-      CL_DEVICE_TYPE_GPU, "NVIDIA Corporation", {
+      kDeviceTypeGPU, kDeviceVendorNVIDIA, {
         { "GeForce GTX 480",  { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
         { "Tesla K20m",       { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
         { "Tesla K40m",       { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
     { // AMD GPUs
-      CL_DEVICE_TYPE_GPU, "Advanced Micro Devices, Inc.", {
+      kDeviceTypeGPU, kDeviceVendorAMD, {
         { "Tahiti",           { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
     { // Intel GPUs
-      CL_DEVICE_TYPE_GPU, "Intel", {
+      kDeviceTypeGPU, kDeviceVendorIntel, {
       }
     },
     { // Default
-      CL_DEVICE_TYPE_ALL, kDefault, {
-        { kDefault,           { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
+      kDeviceTypeAll, kDeviceVendorAll, {
+        { kDefaultDevice,     { {"WGS1",64}, {"WPT1",1}, {"WGS2",64}, {"WPT2",1}, {"VW2",1}, {"WGS3",64}, {"WPT3",1}, {"VW3",1} } },
       }
     },
   }

--- a/include/internal/routine.h
+++ b/include/internal/routine.h
@@ -26,6 +26,7 @@ namespace clblast {
 // =================================================================================================
 
 // See comment at top of file for a description of the class
+template <typename T>
 class Routine {
  public:
 
@@ -52,7 +53,7 @@ class Routine {
   static constexpr bool ErrorIn(const StatusCode s) { return (s != StatusCode::kSuccess); }
 
   // Base class constructor
-  explicit Routine(CommandQueue &queue, Event &event, const std::string &name,
+  explicit Routine(Queue &queue, Event &event, const std::string &name,
                    const std::vector<std::string> &routines, const Precision precision);
 
   // Set-up phase of the kernel
@@ -61,31 +62,31 @@ class Routine {
  protected:
   
   // Runs a kernel given the global and local thread sizes
-  StatusCode RunKernel(const Kernel &kernel, std::vector<size_t> &global,
+  StatusCode RunKernel(Kernel &kernel, std::vector<size_t> &global,
                        const std::vector<size_t> &local);
 
   // Tests for valid inputs of matrices A, B, and C
-  StatusCode TestMatrixA(const size_t one, const size_t two, const Buffer &buffer,
+  StatusCode TestMatrixA(const size_t one, const size_t two, const Buffer<T> &buffer,
                          const size_t offset, const size_t ld, const size_t data_size);
-  StatusCode TestMatrixB(const size_t one, const size_t two, const Buffer &buffer,
+  StatusCode TestMatrixB(const size_t one, const size_t two, const Buffer<T> &buffer,
                          const size_t offset, const size_t ld, const size_t data_size);
-  StatusCode TestMatrixC(const size_t one, const size_t two, const Buffer &buffer,
+  StatusCode TestMatrixC(const size_t one, const size_t two, const Buffer<T> &buffer,
                          const size_t offset, const size_t ld, const size_t data_size);
 
   // Tests for valid inputs of vectors X and Y
-  StatusCode TestVectorX(const size_t n, const Buffer &buffer, const size_t offset,
+  StatusCode TestVectorX(const size_t n, const Buffer<T> &buffer, const size_t offset,
                          const size_t inc, const size_t data_size);
-  StatusCode TestVectorY(const size_t n, const Buffer &buffer, const size_t offset,
+  StatusCode TestVectorY(const size_t n, const Buffer<T> &buffer, const size_t offset,
                          const size_t inc, const size_t data_size);
 
   // Copies/transposes a matrix and padds/unpads it with zeroes. This method is also able to write
   // to symmetric and triangular matrices through optional arguments.
   StatusCode PadCopyTransposeMatrix(const size_t src_one, const size_t src_two,
                                     const size_t src_ld, const size_t src_offset,
-                                    const Buffer &src,
+                                    const Buffer<T> &src,
                                     const size_t dest_one, const size_t dest_two,
                                     const size_t dest_ld, const size_t dest_offset,
-                                    const Buffer &dest,
+                                    const Buffer<T> &dest,
                                     const Program &program, const bool do_pad,
                                     const bool do_transpose, const bool do_conjugate,
                                     const bool upper = false, const bool lower = false,
@@ -106,14 +107,14 @@ class Routine {
   std::string source_string_;
 
   // The OpenCL objects, accessible only from derived classes
-  CommandQueue queue_;
+  Queue queue_;
   Event event_;
   const Context context_;
   const Device device_;
 
   // OpenCL device properties
   const std::string device_name_;
-  const cl_uint max_work_item_dimensions_;
+  const size_t max_work_item_dimensions_;
   const std::vector<size_t> max_work_item_sizes_;
   const size_t max_work_group_size_;
 

--- a/include/internal/routines/level1/xaxpy.h
+++ b/include/internal/routines/level1/xaxpy.h
@@ -21,14 +21,26 @@ namespace clblast {
 
 // See comment at top of file for a description of the class
 template <typename T>
-class Xaxpy: public Routine {
+class Xaxpy: public Routine<T> {
  public:
-  Xaxpy(CommandQueue &queue, Event &event);
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::source_string_;
+  using Routine<T>::queue_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::TestVectorX;
+  using Routine<T>::TestVectorY;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Constructor
+  Xaxpy(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoAxpy(const size_t n, const T alpha,
-                    const Buffer &x_buffer, const size_t x_offset, const size_t x_inc,
-                    const Buffer &y_buffer, const size_t y_offset, const size_t y_inc);
+                    const Buffer<T> &x_buffer, const size_t x_offset, const size_t x_inc,
+                    const Buffer<T> &y_buffer, const size_t y_offset, const size_t y_inc);
 
  private:
   // Static variable to get the precision

--- a/include/internal/routines/level2/xgemv.h
+++ b/include/internal/routines/level2/xgemv.h
@@ -21,18 +21,31 @@ namespace clblast {
 
 // See comment at top of file for a description of the class
 template <typename T>
-class Xgemv: public Routine {
+class Xgemv: public Routine<T> {
  public:
-  Xgemv(CommandQueue &queue, Event &event);
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::source_string_;
+  using Routine<T>::queue_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::TestVectorX;
+  using Routine<T>::TestVectorY;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Constructor
+  Xgemv(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoGemv(const Layout layout, const Transpose a_transpose,
                     const size_t m, const size_t n,
                     const T alpha,
-                    const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                    const Buffer &x_buffer, const size_t x_offset, const size_t x_inc,
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &x_buffer, const size_t x_offset, const size_t x_inc,
                     const T beta,
-                    const Buffer &y_buffer, const size_t y_offset, const size_t y_inc);
+                    const Buffer<T> &y_buffer, const size_t y_offset, const size_t y_inc);
 
  private:
   // Static variable to get the precision

--- a/include/internal/routines/level3/xgemm.h
+++ b/include/internal/routines/level3/xgemm.h
@@ -21,18 +21,33 @@ namespace clblast {
 
 // See comment at top of file for a description of the class
 template <typename T>
-class Xgemm: public Routine {
+class Xgemm: public Routine<T> {
  public:
-  Xgemm(CommandQueue &queue, Event &event);
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::source_string_;
+  using Routine<T>::queue_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::PadCopyTransposeMatrix;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::TestMatrixB;
+  using Routine<T>::TestMatrixC;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Constructor
+  Xgemm(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoGemm(const Layout layout, const Transpose a_transpose, const Transpose b_transpose,
                     const size_t m, const size_t n, const size_t k,
                     const T alpha,
-                    const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                    const Buffer &b_buffer, const size_t b_offset, const size_t b_ld,
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
                     const T beta,
-                    const Buffer &c_buffer, const size_t c_offset, const size_t c_ld);
+                    const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld);
 
  private:
   // Static variable to get the precision

--- a/include/internal/routines/level3/xhemm.h
+++ b/include/internal/routines/level3/xhemm.h
@@ -25,30 +25,28 @@ template <typename T>
 class Xhemm: public Xgemm<T> {
  public:
 
-  // Uses several variables from the Routine class
-  using Routine::db_;
-  using Routine::context_;
-
-  // Uses several helper functions from the Routine class
-  using Routine::RunKernel;
-  using Routine::ErrorIn;
-  using Routine::TestMatrixA;
-  using Routine::GetProgramFromCache;
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
 
   // Uses the regular Xgemm routine
   using Xgemm<T>::DoGemm;
 
   // Constructor
-  Xhemm(CommandQueue &queue, Event &event);
+  Xhemm(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoHemm(const Layout layout, const Side side, const Triangle triangle,
                     const size_t m, const size_t n,
                     const T alpha,
-                    const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                    const Buffer &b_buffer, const size_t b_offset, const size_t b_ld,
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
                     const T beta,
-                    const Buffer &c_buffer, const size_t c_offset, const size_t c_ld);
+                    const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld);
 };
 
 // =================================================================================================

--- a/include/internal/routines/level3/xher2k.h
+++ b/include/internal/routines/level3/xher2k.h
@@ -23,18 +23,33 @@ namespace clblast {
 
 // See comment at top of file for a description of the class
 template <typename T, typename U>
-class Xher2k: public Routine {
+class Xher2k: public Routine<T> {
  public:
-  Xher2k(CommandQueue &queue, Event &event);
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::source_string_;
+  using Routine<T>::queue_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::PadCopyTransposeMatrix;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::TestMatrixB;
+  using Routine<T>::TestMatrixC;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Constructor
+  Xher2k(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoHer2k(const Layout layout, const Triangle triangle, const Transpose ab_transpose,
                      const size_t n, const size_t k,
                      const T alpha,
-                     const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                     const Buffer &b_buffer, const size_t b_offset, const size_t b_ld,
+                     const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                     const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
                      const U beta,
-                     const Buffer &c_buffer, const size_t c_offset, const size_t c_ld);
+                     const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld);
 
  private:
   // Static variable to get the precision

--- a/include/internal/routines/level3/xherk.h
+++ b/include/internal/routines/level3/xherk.h
@@ -23,17 +23,31 @@ namespace clblast {
 
 // See comment at top of file for a description of the class
 template <typename T, typename U>
-class Xherk: public Routine {
+class Xherk: public Routine<T> {
  public:
-  Xherk(CommandQueue &queue, Event &event);
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::source_string_;
+  using Routine<T>::queue_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::PadCopyTransposeMatrix;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::TestMatrixC;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Constructor
+  Xherk(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoHerk(const Layout layout, const Triangle triangle, const Transpose a_transpose,
                     const size_t n, const size_t k,
                     const U alpha,
-                    const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
                     const U beta,
-                    const Buffer &c_buffer, const size_t c_offset, const size_t c_ld);
+                    const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld);
 
  private:
   // Static variable to get the precision

--- a/include/internal/routines/level3/xsymm.h
+++ b/include/internal/routines/level3/xsymm.h
@@ -27,30 +27,28 @@ template <typename T>
 class Xsymm: public Xgemm<T> {
  public:
 
-  // Uses several variables from the Routine class
-  using Routine::db_;
-  using Routine::context_;
-
-  // Uses several helper functions from the Routine class
-  using Routine::RunKernel;
-  using Routine::ErrorIn;
-  using Routine::TestMatrixA;
-  using Routine::GetProgramFromCache;
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
 
   // Uses the regular Xgemm routine
   using Xgemm<T>::DoGemm;
 
   // Constructor
-  Xsymm(CommandQueue &queue, Event &event);
+  Xsymm(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoSymm(const Layout layout, const Side side, const Triangle triangle,
                     const size_t m, const size_t n,
                     const T alpha,
-                    const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                    const Buffer &b_buffer, const size_t b_offset, const size_t b_ld,
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
                     const T beta,
-                    const Buffer &c_buffer, const size_t c_offset, const size_t c_ld);
+                    const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld);
 };
 
 // =================================================================================================

--- a/include/internal/routines/level3/xsyr2k.h
+++ b/include/internal/routines/level3/xsyr2k.h
@@ -23,18 +23,33 @@ namespace clblast {
 
 // See comment at top of file for a description of the class
 template <typename T>
-class Xsyr2k: public Routine {
+class Xsyr2k: public Routine<T> {
  public:
-  Xsyr2k(CommandQueue &queue, Event &event);
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::source_string_;
+  using Routine<T>::queue_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::PadCopyTransposeMatrix;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::TestMatrixB;
+  using Routine<T>::TestMatrixC;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Constructor
+  Xsyr2k(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoSyr2k(const Layout layout, const Triangle triangle, const Transpose ab_transpose,
                      const size_t n, const size_t k,
                      const T alpha,
-                     const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                     const Buffer &b_buffer, const size_t b_offset, const size_t b_ld,
+                     const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                     const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
                      const T beta,
-                     const Buffer &c_buffer, const size_t c_offset, const size_t c_ld);
+                     const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld);
 
  private:
   // Static variable to get the precision

--- a/include/internal/routines/level3/xsyrk.h
+++ b/include/internal/routines/level3/xsyrk.h
@@ -25,17 +25,31 @@ namespace clblast {
 
 // See comment at top of file for a description of the class
 template <typename T>
-class Xsyrk: public Routine {
+class Xsyrk: public Routine<T> {
  public:
-  Xsyrk(CommandQueue &queue, Event &event);
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::source_string_;
+  using Routine<T>::queue_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::PadCopyTransposeMatrix;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::TestMatrixC;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Constructor
+  Xsyrk(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoSyrk(const Layout layout, const Triangle triangle, const Transpose a_transpose,
                     const size_t n, const size_t k,
                     const T alpha,
-                    const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
                     const T beta,
-                    const Buffer &c_buffer, const size_t c_offset, const size_t c_ld);
+                    const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld);
 
  private:
   // Static variable to get the precision

--- a/include/internal/routines/level3/xtrmm.h
+++ b/include/internal/routines/level3/xtrmm.h
@@ -26,29 +26,27 @@ template <typename T>
 class Xtrmm: public Xgemm<T> {
  public:
 
-  // Uses several variables from the Routine class
-  using Routine::db_;
-  using Routine::context_;
-
-  // Uses several helper functions from the Routine class
-  using Routine::RunKernel;
-  using Routine::ErrorIn;
-  using Routine::TestMatrixA;
-  using Routine::GetProgramFromCache;
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
 
   // Uses the regular Xgemm routine
   using Xgemm<T>::DoGemm;
 
   // Constructor
-  Xtrmm(CommandQueue &queue, Event &event);
+  Xtrmm(Queue &queue, Event &event);
 
   // Templated-precision implementation of the routine
   StatusCode DoTrmm(const Layout layout, const Side side, const Triangle triangle,
                     const Transpose a_transpose, const Diagonal diagonal,
                     const size_t m, const size_t n,
                     const T alpha,
-                    const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                    const Buffer &b_buffer, const size_t b_offset, const size_t b_ld);
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld);
 };
 
 // =================================================================================================

--- a/include/internal/utilities.h
+++ b/include/internal/utilities.h
@@ -131,12 +131,13 @@ struct Arguments {
 };
 
 // Structure containing all possible buffers for test clients
+template <typename T>
 struct Buffers {
-  Buffer x_vec;
-  Buffer y_vec;
-  Buffer a_mat;
-  Buffer b_mat;
-  Buffer c_mat;
+  Buffer<T> x_vec;
+  Buffer<T> y_vec;
+  Buffer<T> a_mat;
+  Buffer<T> b_mat;
+  Buffer<T> c_mat;
 };
 
 // =================================================================================================

--- a/src/clblast.cc
+++ b/src/clblast.cc
@@ -43,7 +43,7 @@ StatusCode Axpy(const size_t n, const T alpha,
                 const cl_mem x_buffer, const size_t x_offset, const size_t x_inc,
                 cl_mem y_buffer, const size_t y_offset, const size_t y_inc,
                 cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xaxpy<T>(queue_cpp, event_cpp);
 
@@ -53,8 +53,8 @@ StatusCode Axpy(const size_t n, const T alpha,
 
   // Runs the routine
   return routine.DoAxpy(n, alpha,
-                        Buffer(x_buffer), x_offset, x_inc,
-                        Buffer(y_buffer), y_offset, y_inc);
+                        Buffer<T>(x_buffer), x_offset, x_inc,
+                        Buffer<T>(y_buffer), y_offset, y_inc);
 }
 template StatusCode Axpy<float>(const size_t, const float,
                                 const cl_mem, const size_t, const size_t,
@@ -85,7 +85,7 @@ StatusCode Gemv(const Layout layout, const Transpose a_transpose,
                 cl_mem y_buffer, const size_t y_offset, const size_t y_inc,
                 cl_command_queue* queue, cl_event* event) {
   
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xgemv<T>(queue_cpp, event_cpp);
 
@@ -95,9 +95,9 @@ StatusCode Gemv(const Layout layout, const Transpose a_transpose,
 
   // Runs the routine
   return routine.DoGemv(layout, a_transpose, m, n, alpha,
-                        Buffer(a_buffer), a_offset, a_ld,
-                        Buffer(x_buffer), x_offset, x_inc, beta,
-                        Buffer(y_buffer), y_offset, y_inc);
+                        Buffer<T>(a_buffer), a_offset, a_ld,
+                        Buffer<T>(x_buffer), x_offset, x_inc, beta,
+                        Buffer<T>(y_buffer), y_offset, y_inc);
 }
 template StatusCode Gemv<float>(const Layout, const Transpose,
                                 const size_t, const size_t, const float,
@@ -135,7 +135,7 @@ StatusCode Gemm(const Layout layout, const Transpose a_transpose, const Transpos
                 const cl_mem b_buffer, const size_t b_offset, const size_t b_ld, const T beta,
                 cl_mem c_buffer, const size_t c_offset, const size_t c_ld,
                 cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xgemm<T>(queue_cpp, event_cpp);
 
@@ -145,9 +145,9 @@ StatusCode Gemm(const Layout layout, const Transpose a_transpose, const Transpos
 
   // Runs the routine
   return routine.DoGemm(layout, a_transpose, b_transpose, m, n, k, alpha,
-                        Buffer(a_buffer), a_offset, a_ld,
-                        Buffer(b_buffer), b_offset, b_ld, beta,
-                        Buffer(c_buffer), c_offset, c_ld);
+                        Buffer<T>(a_buffer), a_offset, a_ld,
+                        Buffer<T>(b_buffer), b_offset, b_ld, beta,
+                        Buffer<T>(c_buffer), c_offset, c_ld);
 }
 template StatusCode Gemm<float>(const Layout, const Transpose, const Transpose,
                                 const size_t, const size_t, const size_t, const float,
@@ -184,7 +184,7 @@ StatusCode Symm(const Layout layout, const Side side, const Triangle triangle,
                 const cl_mem b_buffer, const size_t b_offset, const size_t b_ld, const T beta,
                 cl_mem c_buffer, const size_t c_offset, const size_t c_ld,
                 cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xsymm<T>(queue_cpp, event_cpp);
 
@@ -194,9 +194,9 @@ StatusCode Symm(const Layout layout, const Side side, const Triangle triangle,
 
   // Runs the routine
   return routine.DoSymm(layout, side, triangle, m, n, alpha,
-                        Buffer(a_buffer), a_offset, a_ld,
-                        Buffer(b_buffer), b_offset, b_ld, beta,
-                        Buffer(c_buffer), c_offset, c_ld);
+                        Buffer<T>(a_buffer), a_offset, a_ld,
+                        Buffer<T>(b_buffer), b_offset, b_ld, beta,
+                        Buffer<T>(c_buffer), c_offset, c_ld);
 }
 template StatusCode Symm<float>(const Layout, const Side, const Triangle,
                                 const size_t, const size_t, const float,
@@ -233,7 +233,7 @@ StatusCode Hemm(const Layout layout, const Side side, const Triangle triangle,
                 const cl_mem b_buffer, const size_t b_offset, const size_t b_ld, const T beta,
                 cl_mem c_buffer, const size_t c_offset, const size_t c_ld,
                 cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xhemm<T>(queue_cpp, event_cpp);
 
@@ -243,9 +243,9 @@ StatusCode Hemm(const Layout layout, const Side side, const Triangle triangle,
 
   // Runs the routine
   return routine.DoHemm(layout, side, triangle, m, n, alpha,
-                        Buffer(a_buffer), a_offset, a_ld,
-                        Buffer(b_buffer), b_offset, b_ld, beta,
-                        Buffer(c_buffer), c_offset, c_ld);
+                        Buffer<T>(a_buffer), a_offset, a_ld,
+                        Buffer<T>(b_buffer), b_offset, b_ld, beta,
+                        Buffer<T>(c_buffer), c_offset, c_ld);
 }
 template StatusCode Hemm<float2>(const Layout, const Side, const Triangle,
                                  const size_t, const size_t, const float2,
@@ -269,7 +269,7 @@ StatusCode Syrk(const Layout layout, const Triangle triangle, const Transpose a_
                 const cl_mem a_buffer, const size_t a_offset, const size_t a_ld, const T beta,
                 cl_mem c_buffer, const size_t c_offset, const size_t c_ld,
                 cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xsyrk<T>(queue_cpp, event_cpp);
 
@@ -279,8 +279,8 @@ StatusCode Syrk(const Layout layout, const Triangle triangle, const Transpose a_
 
   // Runs the routine
   return routine.DoSyrk(layout, triangle, a_transpose, n, k, alpha,
-                        Buffer(a_buffer), a_offset, a_ld, beta,
-                        Buffer(c_buffer), c_offset, c_ld);
+                        Buffer<T>(a_buffer), a_offset, a_ld, beta,
+                        Buffer<T>(c_buffer), c_offset, c_ld);
 }
 template StatusCode Syrk<float>(const Layout, const Triangle, const Transpose,
                                 const size_t, const size_t, const float,
@@ -312,7 +312,7 @@ StatusCode Herk(const Layout layout, const Triangle triangle, const Transpose a_
                 const cl_mem a_buffer, const size_t a_offset, const size_t a_ld, const T beta,
                 cl_mem c_buffer, const size_t c_offset, const size_t c_ld,
                 cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xherk<std::complex<T>,T>(queue_cpp, event_cpp);
 
@@ -322,8 +322,8 @@ StatusCode Herk(const Layout layout, const Triangle triangle, const Transpose a_
 
   // Runs the routine
   return routine.DoHerk(layout, triangle, a_transpose, n, k, alpha,
-                        Buffer(a_buffer), a_offset, a_ld, beta,
-                        Buffer(c_buffer), c_offset, c_ld);
+                        Buffer<std::complex<T>>(a_buffer), a_offset, a_ld, beta,
+                        Buffer<std::complex<T>>(c_buffer), c_offset, c_ld);
 }
 template StatusCode Herk<float>(const Layout, const Triangle, const Transpose,
                                 const size_t, const size_t, const float,
@@ -346,7 +346,7 @@ StatusCode Syr2k(const Layout layout, const Triangle triangle, const Transpose a
                  const cl_mem b_buffer, const size_t b_offset, const size_t b_ld, const T beta,
                  cl_mem c_buffer, const size_t c_offset, const size_t c_ld,
                  cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xsyr2k<T>(queue_cpp, event_cpp);
 
@@ -356,9 +356,9 @@ StatusCode Syr2k(const Layout layout, const Triangle triangle, const Transpose a
 
   // Runs the routine
   return routine.DoSyr2k(layout, triangle, ab_transpose, n, k, alpha,
-                         Buffer(a_buffer), a_offset, a_ld,
-                         Buffer(b_buffer), b_offset, b_ld, beta,
-                         Buffer(c_buffer), c_offset, c_ld);
+                         Buffer<T>(a_buffer), a_offset, a_ld,
+                         Buffer<T>(b_buffer), b_offset, b_ld, beta,
+                         Buffer<T>(c_buffer), c_offset, c_ld);
 }
 template StatusCode Syr2k<float>(const Layout, const Triangle, const Transpose,
                                  const size_t, const size_t, const float,
@@ -395,7 +395,7 @@ StatusCode Her2k(const Layout layout, const Triangle triangle, const Transpose a
                  const cl_mem b_buffer, const size_t b_offset, const size_t b_ld, const U beta,
                  cl_mem c_buffer, const size_t c_offset, const size_t c_ld,
                  cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xher2k<T,U>(queue_cpp, event_cpp);
 
@@ -405,9 +405,9 @@ StatusCode Her2k(const Layout layout, const Triangle triangle, const Transpose a
 
   // Runs the routine
   return routine.DoHer2k(layout, triangle, ab_transpose, n, k, alpha,
-                         Buffer(a_buffer), a_offset, a_ld,
-                         Buffer(b_buffer), b_offset, b_ld, beta,
-                         Buffer(c_buffer), c_offset, c_ld);
+                         Buffer<T>(a_buffer), a_offset, a_ld,
+                         Buffer<T>(b_buffer), b_offset, b_ld, beta,
+                         Buffer<T>(c_buffer), c_offset, c_ld);
 }
 template StatusCode Her2k<float2,float>(const Layout, const Triangle, const Transpose,
                                         const size_t, const size_t, const float2,
@@ -433,7 +433,7 @@ StatusCode Trmm(const Layout layout, const Side side, const Triangle triangle,
                 const cl_mem a_buffer, const size_t a_offset, const size_t a_ld,
                 cl_mem b_buffer, const size_t b_offset, const size_t b_ld,
                 cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xtrmm<T>(queue_cpp, event_cpp);
 
@@ -443,8 +443,8 @@ StatusCode Trmm(const Layout layout, const Side side, const Triangle triangle,
 
   // Runs the routine
   return routine.DoTrmm(layout, side, triangle, a_transpose, diagonal, m, n, alpha,
-                        Buffer(a_buffer), a_offset, a_ld,
-                        Buffer(b_buffer), b_offset, b_ld);
+                        Buffer<T>(a_buffer), a_offset, a_ld,
+                        Buffer<T>(b_buffer), b_offset, b_ld);
 }
 template StatusCode Trmm<float>(const Layout, const Side, const Triangle,
                                 const Transpose, const Diagonal,
@@ -483,7 +483,7 @@ StatusCode Trsm(const Layout layout, const Side side, const Triangle triangle,
                 const cl_mem a_buffer, const size_t a_offset, const size_t a_ld,
                 cl_mem b_buffer, const size_t b_offset, const size_t b_ld,
                 cl_command_queue* queue, cl_event* event) {
-  auto queue_cpp = CommandQueue(*queue);
+  auto queue_cpp = Queue(*queue);
   auto event_cpp = Event(*event);
   auto routine = Xtrsm<T>(queue_cpp, event_cpp);
 
@@ -493,8 +493,8 @@ StatusCode Trsm(const Layout layout, const Side side, const Triangle triangle,
 
   // Runs the routine
   return routine.DoTrsm(layout, side, triangle, a_transpose, diagonal, m, n, alpha,
-                        Buffer(a_buffer), a_offset, a_ld,
-                        Buffer(b_buffer), b_offset, b_ld);
+                        Buffer<T>(a_buffer), a_offset, a_ld,
+                        Buffer<T>(b_buffer), b_offset, b_ld);
 }
 template StatusCode Trsm<float>(const Layout, const Side, const Triangle,
                                 const Transpose, const Diagonal,

--- a/src/database.cc
+++ b/src/database.cc
@@ -39,7 +39,7 @@ const std::vector<Database::DatabaseEntry> Database::database = {
 // =================================================================================================
 
 // Constructor, computing device properties and populating the parameter-vector from the database
-Database::Database(const CommandQueue &queue, const std::vector<std::string> &kernels,
+Database::Database(const Queue &queue, const std::vector<std::string> &kernels,
                    const Precision precision):
   parameters_{} {
 
@@ -71,7 +71,7 @@ std::string Database::GetDefines() const {
 
 // Searches the database for the right kernel and precision
 Database::Parameters Database::Search(const std::string &this_kernel,
-                                      const cl_device_type this_type,
+                                      const std::string &this_type,
                                       const std::string &this_vendor,
                                       const std::string &this_device,
                                       const Precision this_precision) const {
@@ -81,13 +81,13 @@ Database::Parameters Database::Search(const std::string &this_kernel,
       // Searches for the right vendor and device type, or selects the default if unavailable. This
       // assumes that the default vendor / device type is last in the database.
       for (auto &vendor: db.vendors) {
-        if (VendorEqual(vendor.name, this_vendor) &&
-            (vendor.type == this_type || vendor.type == CL_DEVICE_TYPE_ALL)) {
+        if ((vendor.name == this_vendor || vendor.name == kDeviceVendorAll) &&
+            (vendor.type == this_type   || vendor.type == kDeviceTypeAll)) {
 
           // Searches for the right device. If the current device is unavailable, selects the vendor
           // default parameters. This assumes the default is last in the database.
           for (auto &device: vendor.devices) {
-            if (device.name == this_device || device.name == kDefault) {
+            if (device.name == this_device || device.name == kDefaultDevice) {
 
               // Sets the parameters accordingly
               return device.parameters;
@@ -100,14 +100,6 @@ Database::Parameters Database::Search(const std::string &this_kernel,
 
   // If we reached this point, something is wrong
   throw std::runtime_error("Database error, could not find a suitable entry");
-}
-
-// Determines the equality between two vendor names. This is implemented because vendor names can
-// be ambigious and might change between different SDK or driver versions.
-bool Database::VendorEqual(const std::string &db_vendor, const std::string &cl_vendor) const {
-  if (db_vendor == kDefault) { return true; }
-  if (db_vendor == cl_vendor) { return true; }
-  return false;
 }
 
 // =================================================================================================

--- a/src/routines/level1/xaxpy.cc
+++ b/src/routines/level1/xaxpy.cc
@@ -29,8 +29,8 @@ template <> const Precision Xaxpy<double2>::precision_ = Precision::kComplexDoub
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xaxpy<T>::Xaxpy(CommandQueue &queue, Event &event):
-    Routine(queue, event, "AXPY", {"Xaxpy"}, precision_) {
+Xaxpy<T>::Xaxpy(Queue &queue, Event &event):
+    Routine<T>(queue, event, "AXPY", {"Xaxpy"}, precision_) {
   source_string_ =
     #include "../../kernels/xaxpy.opencl"
   ;
@@ -41,8 +41,8 @@ Xaxpy<T>::Xaxpy(CommandQueue &queue, Event &event):
 // The main routine
 template <typename T>
 StatusCode Xaxpy<T>::DoAxpy(const size_t n, const T alpha,
-                            const Buffer &x_buffer, const size_t x_offset, const size_t x_inc,
-                            const Buffer &y_buffer, const size_t y_offset, const size_t y_inc) {
+                            const Buffer<T> &x_buffer, const size_t x_offset, const size_t x_inc,
+                            const Buffer<T> &y_buffer, const size_t y_offset, const size_t y_inc) {
 
   // Makes sure all dimensions are larger than zero
   if (n == 0) { return StatusCode::kInvalidDimension; }

--- a/src/routines/level2/xgemv.cc
+++ b/src/routines/level2/xgemv.cc
@@ -29,8 +29,8 @@ template <> const Precision Xgemv<double2>::precision_ = Precision::kComplexDoub
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xgemv<T>::Xgemv(CommandQueue &queue, Event &event):
-    Routine(queue, event, "GEMV", {"Xgemv"}, precision_) {
+Xgemv<T>::Xgemv(Queue &queue, Event &event):
+    Routine<T>(queue, event, "GEMV", {"Xgemv"}, precision_) {
   source_string_ =
     #include "../../kernels/xgemv.opencl"
   ;
@@ -43,10 +43,10 @@ template <typename T>
 StatusCode Xgemv<T>::DoGemv(const Layout layout, const Transpose a_transpose,
                             const size_t m, const size_t n,
                             const T alpha,
-                            const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                            const Buffer &x_buffer, const size_t x_offset, const size_t x_inc,
+                            const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                            const Buffer<T> &x_buffer, const size_t x_offset, const size_t x_inc,
                             const T beta,
-                            const Buffer &y_buffer, const size_t y_offset, const size_t y_inc) {
+                            const Buffer<T> &y_buffer, const size_t y_offset, const size_t y_inc) {
 
   // Makes sure all dimensions are larger than zero
   if (m == 0 || n == 0) { return StatusCode::kInvalidDimension; }

--- a/src/routines/level3/xhemm.cc
+++ b/src/routines/level3/xhemm.cc
@@ -21,7 +21,7 @@ namespace clblast {
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xhemm<T>::Xhemm(CommandQueue &queue, Event &event):
+Xhemm<T>::Xhemm(Queue &queue, Event &event):
     Xgemm<T>(queue, event) {
 }
 
@@ -32,10 +32,10 @@ template <typename T>
 StatusCode Xhemm<T>::DoHemm(const Layout layout, const Side side, const Triangle triangle,
                             const size_t m, const size_t n,
                             const T alpha,
-                            const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                            const Buffer &b_buffer, const size_t b_offset, const size_t b_ld,
+                            const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                            const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
                             const T beta,
-                            const Buffer &c_buffer, const size_t c_offset, const size_t c_ld) {
+                            const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld) {
 
   // Makes sure all dimensions are larger than zero
   if ((m == 0) || (n == 0) ) { return StatusCode::kInvalidDimension; }
@@ -56,7 +56,7 @@ StatusCode Xhemm<T>::DoHemm(const Layout layout, const Side side, const Triangle
 
   // Temporary buffer for a copy of the hermitian matrix
   try {
-    auto temp_herm = Buffer(context_, CL_MEM_READ_WRITE, k*k*sizeof(T));
+    auto temp_herm = Buffer<T>(context_, k*k);
 
     // Creates a general matrix from the hermitian matrix to be able to run the regular Xgemm
     // routine afterwards

--- a/src/routines/level3/xsymm.cc
+++ b/src/routines/level3/xsymm.cc
@@ -21,7 +21,7 @@ namespace clblast {
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xsymm<T>::Xsymm(CommandQueue &queue, Event &event):
+Xsymm<T>::Xsymm(Queue &queue, Event &event):
     Xgemm<T>(queue, event) {
 }
 
@@ -32,10 +32,10 @@ template <typename T>
 StatusCode Xsymm<T>::DoSymm(const Layout layout, const Side side, const Triangle triangle,
                             const size_t m, const size_t n,
                             const T alpha,
-                            const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                            const Buffer &b_buffer, const size_t b_offset, const size_t b_ld,
+                            const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                            const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
                             const T beta,
-                            const Buffer &c_buffer, const size_t c_offset, const size_t c_ld) {
+                            const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld) {
 
   // Makes sure all dimensions are larger than zero
   if ((m == 0) || (n == 0) ) { return StatusCode::kInvalidDimension; }
@@ -56,7 +56,7 @@ StatusCode Xsymm<T>::DoSymm(const Layout layout, const Side side, const Triangle
 
   // Temporary buffer for a copy of the symmetric matrix
   try {
-    auto temp_symm = Buffer(context_, CL_MEM_READ_WRITE, k*k*sizeof(T));
+    auto temp_symm = Buffer<T>(context_, k*k);
 
     // Creates a general matrix from the symmetric matrix to be able to run the regular Xgemm
     // routine afterwards

--- a/src/routines/level3/xsyr2k.cc
+++ b/src/routines/level3/xsyr2k.cc
@@ -29,8 +29,8 @@ template <> const Precision Xsyr2k<double2>::precision_ = Precision::kComplexDou
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xsyr2k<T>::Xsyr2k(CommandQueue &queue, Event &event):
-    Routine(queue, event, "SYR2K", {"Copy","Pad","Transpose","PadTranspose","Xgemm"}, precision_) {
+Xsyr2k<T>::Xsyr2k(Queue &queue, Event &event):
+    Routine<T>(queue, event, "SYR2K", {"Copy","Pad","Transpose","PadTranspose","Xgemm"}, precision_) {
   source_string_ =
     #include "../../kernels/copy.opencl"
     #include "../../kernels/pad.opencl"
@@ -47,10 +47,10 @@ template <typename T>
 StatusCode Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, const Transpose ab_transpose,
                               const size_t n, const size_t k,
                               const T alpha,
-                              const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                              const Buffer &b_buffer, const size_t b_offset, const size_t b_ld,
+                              const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                              const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
                               const T beta,
-                              const Buffer &c_buffer, const size_t c_offset, const size_t c_ld) {
+                              const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld) {
 
   // Makes sure all dimensions are larger than zero
   if ((n == 0) || (k == 0) ) { return StatusCode::kInvalidDimension; }
@@ -99,9 +99,9 @@ StatusCode Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, cons
                      ab_rotated == false;
 
     // Creates the temporary matrices
-    auto a_temp = (a_no_temp) ? a_buffer : Buffer(context_, CL_MEM_READ_WRITE, k_ceiled*n_ceiled*sizeof(T));
-    auto b_temp = (b_no_temp) ? b_buffer : Buffer(context_, CL_MEM_READ_WRITE, k_ceiled*n_ceiled*sizeof(T));
-    auto c_temp = Buffer(context_, CL_MEM_READ_WRITE, n_ceiled*n_ceiled*sizeof(T));
+    auto a_temp = (a_no_temp) ? a_buffer : Buffer<T>(context_, k_ceiled*n_ceiled);
+    auto b_temp = (b_no_temp) ? b_buffer : Buffer<T>(context_, k_ceiled*n_ceiled);
+    auto c_temp = Buffer<T>(context_, n_ceiled*n_ceiled);
 
     // Runs the pre-processing kernels. This transposes the matrices A and B, but also pads zeros to
     // to fill it up until it reaches a certain multiple of size (kernel parameter dependent). In

--- a/src/routines/level3/xsyrk.cc
+++ b/src/routines/level3/xsyrk.cc
@@ -29,8 +29,8 @@ template <> const Precision Xsyrk<double2>::precision_ = Precision::kComplexDoub
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xsyrk<T>::Xsyrk(CommandQueue &queue, Event &event):
-    Routine(queue, event, "SYRK", {"Copy","Pad","Transpose","PadTranspose","Xgemm"}, precision_) {
+Xsyrk<T>::Xsyrk(Queue &queue, Event &event):
+    Routine<T>(queue, event, "SYRK", {"Copy","Pad","Transpose","PadTranspose","Xgemm"}, precision_) {
   source_string_ =
     #include "../../kernels/copy.opencl"
     #include "../../kernels/pad.opencl"
@@ -47,9 +47,9 @@ template <typename T>
 StatusCode Xsyrk<T>::DoSyrk(const Layout layout, const Triangle triangle, const Transpose a_transpose,
                             const size_t n, const size_t k,
                             const T alpha,
-                            const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
+                            const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
                             const T beta,
-                            const Buffer &c_buffer, const size_t c_offset, const size_t c_ld) {
+                            const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld) {
 
   // Makes sure all dimensions are larger than zero
   if ((n == 0) || (k == 0) ) { return StatusCode::kInvalidDimension; }
@@ -93,8 +93,8 @@ StatusCode Xsyrk<T>::DoSyrk(const Layout layout, const Triangle triangle, const 
                      a_rotated == false;
 
     // Creates the temporary matrices
-    auto a_temp = (a_no_temp) ? a_buffer : Buffer(context_, CL_MEM_READ_WRITE, k_ceiled*n_ceiled*sizeof(T));
-    auto c_temp = Buffer(context_, CL_MEM_READ_WRITE, n_ceiled*n_ceiled*sizeof(T));
+    auto a_temp = (a_no_temp) ? a_buffer : Buffer<T>(context_, k_ceiled*n_ceiled);
+    auto c_temp = Buffer<T>(context_, n_ceiled*n_ceiled);
 
     // Runs the pre-processing kernel for matrix A. This transposes the matrix, but also pads zeros
     // to fill it up until it reaches a certain multiple of size (kernel parameter dependent). In

--- a/src/routines/level3/xtrmm.cc
+++ b/src/routines/level3/xtrmm.cc
@@ -21,7 +21,7 @@ namespace clblast {
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xtrmm<T>::Xtrmm(CommandQueue &queue, Event &event):
+Xtrmm<T>::Xtrmm(Queue &queue, Event &event):
     Xgemm<T>(queue, event) {
 }
 
@@ -33,8 +33,8 @@ StatusCode Xtrmm<T>::DoTrmm(const Layout layout, const Side side, const Triangle
                             const Transpose a_transpose, const Diagonal diagonal,
                             const size_t m, const size_t n,
                             const T alpha,
-                            const Buffer &a_buffer, const size_t a_offset, const size_t a_ld,
-                            const Buffer &b_buffer, const size_t b_offset, const size_t b_ld) {
+                            const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                            const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld) {
 
   // Makes sure all dimensions are larger than zero
   if ((m == 0) || (n == 0)) { return StatusCode::kInvalidDimension; }
@@ -58,7 +58,7 @@ StatusCode Xtrmm<T>::DoTrmm(const Layout layout, const Side side, const Triangle
 
   // Temporary buffer for a copy of the triangular matrix
   try {
-    auto temp_triangular = Buffer(context_, CL_MEM_READ_WRITE, k*k*sizeof(T));
+    auto temp_triangular = Buffer<T>(context_, k*k);
 
     // Creates a general matrix from the triangular matrix to be able to run the regular Xgemm
     // routine afterwards

--- a/test/correctness/testblas.cc
+++ b/test/correctness/testblas.cc
@@ -76,31 +76,31 @@ void TestBlas<T,U>::TestRegular(std::vector<Arguments<U>> &test_vector, const st
   for (auto &args: test_vector) {
 
     // Runs the reference clBLAS code
-    auto x_vec1 = Buffer(context_, CL_MEM_READ_WRITE, args.x_size*sizeof(T));
-    auto y_vec1 = Buffer(context_, CL_MEM_READ_WRITE, args.y_size*sizeof(T));
-    auto a_mat1 = Buffer(context_, CL_MEM_READ_WRITE, args.a_size*sizeof(T));
-    auto b_mat1 = Buffer(context_, CL_MEM_READ_WRITE, args.b_size*sizeof(T));
-    auto c_mat1 = Buffer(context_, CL_MEM_READ_WRITE, args.c_size*sizeof(T));
-    x_vec1.WriteBuffer(queue_, args.x_size*sizeof(T), x_source_);
-    y_vec1.WriteBuffer(queue_, args.y_size*sizeof(T), y_source_);
-    a_mat1.WriteBuffer(queue_, args.a_size*sizeof(T), a_source_);
-    b_mat1.WriteBuffer(queue_, args.b_size*sizeof(T), b_source_);
-    c_mat1.WriteBuffer(queue_, args.c_size*sizeof(T), c_source_);
-    auto buffers1 = Buffers{x_vec1, y_vec1, a_mat1, b_mat1, c_mat1};
+    auto x_vec1 = Buffer<T>(context_, args.x_size);
+    auto y_vec1 = Buffer<T>(context_, args.y_size);
+    auto a_mat1 = Buffer<T>(context_, args.a_size);
+    auto b_mat1 = Buffer<T>(context_, args.b_size);
+    auto c_mat1 = Buffer<T>(context_, args.c_size);
+    x_vec1.Write(queue_, args.x_size, x_source_);
+    y_vec1.Write(queue_, args.y_size, y_source_);
+    a_mat1.Write(queue_, args.a_size, a_source_);
+    b_mat1.Write(queue_, args.b_size, b_source_);
+    c_mat1.Write(queue_, args.c_size, c_source_);
+    auto buffers1 = Buffers<T>{x_vec1, y_vec1, a_mat1, b_mat1, c_mat1};
     auto status1 = run_reference_(args, buffers1, queue_);
 
     // Runs the CLBlast code
-    auto x_vec2 = Buffer(context_, CL_MEM_READ_WRITE, args.x_size*sizeof(T));
-    auto y_vec2 = Buffer(context_, CL_MEM_READ_WRITE, args.y_size*sizeof(T));
-    auto a_mat2 = Buffer(context_, CL_MEM_READ_WRITE, args.a_size*sizeof(T));
-    auto b_mat2 = Buffer(context_, CL_MEM_READ_WRITE, args.b_size*sizeof(T));
-    auto c_mat2 = Buffer(context_, CL_MEM_READ_WRITE, args.c_size*sizeof(T));
-    x_vec2.WriteBuffer(queue_, args.x_size*sizeof(T), x_source_);
-    y_vec2.WriteBuffer(queue_, args.y_size*sizeof(T), y_source_);
-    a_mat2.WriteBuffer(queue_, args.a_size*sizeof(T), a_source_);
-    b_mat2.WriteBuffer(queue_, args.b_size*sizeof(T), b_source_);
-    c_mat2.WriteBuffer(queue_, args.c_size*sizeof(T), c_source_);
-    auto buffers2 = Buffers{x_vec2, y_vec2, a_mat2, b_mat2, c_mat2};
+    auto x_vec2 = Buffer<T>(context_, args.x_size);
+    auto y_vec2 = Buffer<T>(context_, args.y_size);
+    auto a_mat2 = Buffer<T>(context_, args.a_size);
+    auto b_mat2 = Buffer<T>(context_, args.b_size);
+    auto c_mat2 = Buffer<T>(context_, args.c_size);
+    x_vec2.Write(queue_, args.x_size, x_source_);
+    y_vec2.Write(queue_, args.y_size, y_source_);
+    a_mat2.Write(queue_, args.a_size, a_source_);
+    b_mat2.Write(queue_, args.b_size, b_source_);
+    c_mat2.Write(queue_, args.c_size, c_source_);
+    auto buffers2 = Buffers<T>{x_vec2, y_vec2, a_mat2, b_mat2, c_mat2};
     auto status2 = run_routine_(args, buffers2, queue_);
 
     // Tests for equality of the two status codes
@@ -149,25 +149,25 @@ void TestBlas<T,U>::TestInvalid(std::vector<Arguments<U>> &test_vector, const st
     auto a1 = clCreateBuffer(context_(), CL_MEM_READ_WRITE, args.a_size*sizeof(T), nullptr,nullptr);
     auto b1 = clCreateBuffer(context_(), CL_MEM_READ_WRITE, args.b_size*sizeof(T), nullptr,nullptr);
     auto c1 = clCreateBuffer(context_(), CL_MEM_READ_WRITE, args.c_size*sizeof(T), nullptr,nullptr);
-    auto x_vec1 = Buffer(x1);
-    auto y_vec1 = Buffer(y1);
-    auto a_mat1 = Buffer(a1);
-    auto b_mat1 = Buffer(b1);
-    auto c_mat1 = Buffer(c1);
+    auto x_vec1 = Buffer<T>(x1);
+    auto y_vec1 = Buffer<T>(y1);
+    auto a_mat1 = Buffer<T>(a1);
+    auto b_mat1 = Buffer<T>(b1);
+    auto c_mat1 = Buffer<T>(c1);
     auto x2 = clCreateBuffer(context_(), CL_MEM_READ_WRITE, args.x_size*sizeof(T), nullptr,nullptr);
     auto y2 = clCreateBuffer(context_(), CL_MEM_READ_WRITE, args.y_size*sizeof(T), nullptr,nullptr);
     auto a2 = clCreateBuffer(context_(), CL_MEM_READ_WRITE, args.a_size*sizeof(T), nullptr,nullptr);
     auto b2 = clCreateBuffer(context_(), CL_MEM_READ_WRITE, args.b_size*sizeof(T), nullptr,nullptr);
     auto c2 = clCreateBuffer(context_(), CL_MEM_READ_WRITE, args.c_size*sizeof(T), nullptr,nullptr);
-    auto x_vec2 = Buffer(x2);
-    auto y_vec2 = Buffer(y2);
-    auto a_mat2 = Buffer(a2);
-    auto b_mat2 = Buffer(b2);
-    auto c_mat2 = Buffer(c2);
+    auto x_vec2 = Buffer<T>(x2);
+    auto y_vec2 = Buffer<T>(y2);
+    auto a_mat2 = Buffer<T>(a2);
+    auto b_mat2 = Buffer<T>(b2);
+    auto c_mat2 = Buffer<T>(c2);
 
     // Runs the two routines
-    auto status1 = run_reference_(args, Buffers{x_vec1, y_vec1, a_mat1, b_mat1, c_mat1}, queue_);
-    auto status2 = run_routine_(args, Buffers{x_vec2, y_vec2, a_mat2, b_mat2, c_mat2}, queue_);
+    auto status1 = run_reference_(args, Buffers<T>{x_vec1, y_vec1, a_mat1, b_mat1, c_mat1}, queue_);
+    auto status2 = run_routine_(args, Buffers<T>{x_vec2, y_vec2, a_mat2, b_mat2, c_mat2}, queue_);
 
     // Tests for equality of the two status codes
     TestErrorCodes(status1, status2, args);

--- a/test/correctness/testblas.h
+++ b/test/correctness/testblas.h
@@ -66,8 +66,8 @@ class TestBlas: public Tester<T,U> {
   static const std::vector<Transpose> kTransposes; // Data-type dependent, see .cc-file
 
   // Shorthand for the routine-specific functions passed to the tester
-  using Routine = std::function<StatusCode(const Arguments<U>&, const Buffers&, CommandQueue&)>;
-  using ResultGet = std::function<std::vector<T>(const Arguments<U>&, Buffers&, CommandQueue&)>;
+  using Routine = std::function<StatusCode(const Arguments<U>&, const Buffers<T>&, Queue&)>;
+  using ResultGet = std::function<std::vector<T>(const Arguments<U>&, Buffers<T>&, Queue&)>;
   using ResultIndex = std::function<size_t(const Arguments<U>&, const size_t, const size_t)>;
   using ResultIterator = std::function<size_t(const Arguments<U>&)>;
 

--- a/test/correctness/tester.cc
+++ b/test/correctness/tester.cc
@@ -28,9 +28,9 @@ Tester<T,U>::Tester(int argc, char *argv[], const bool silent,
                     const std::string &name, const std::vector<std::string> &options):
     help_("Options given/available:\n"),
     platform_(Platform(GetArgument(argc, argv, help_, kArgPlatform, size_t{0}))),
-    device_(Device(platform_, kDeviceType, GetArgument(argc, argv, help_, kArgDevice, size_t{0}))),
+    device_(Device(platform_, GetArgument(argc, argv, help_, kArgDevice, size_t{0}))),
     context_(Context(device_)),
-    queue_(CommandQueue(context_, device_)),
+    queue_(Queue(context_, device_)),
     full_test_(CheckArgument(argc, argv, help_, kArgFullTest)),
     error_log_{},
     num_passed_{0},
@@ -339,11 +339,11 @@ template <> const std::vector<double2> GetExampleScalars(const bool full_test) {
 template <> bool PrecisionSupported<float>(const Device &) { return true; }
 template <> bool PrecisionSupported<float2>(const Device &) { return true; }
 template <> bool PrecisionSupported<double>(const Device &device) {
-  auto extensions = device.Extensions();
+  auto extensions = device.Capabilities();
   return (extensions.find(kKhronosDoublePrecision) == std::string::npos) ? false : true;
 }
 template <> bool PrecisionSupported<double2>(const Device &device) {
-  auto extensions = device.Extensions();
+  auto extensions = device.Capabilities();
   return (extensions.find(kKhronosDoublePrecision) == std::string::npos) ? false : true;
 }
 

--- a/test/correctness/tester.h
+++ b/test/correctness/tester.h
@@ -36,9 +36,6 @@ template <typename T, typename U>
 class Tester {
  public:
 
-  // Types of devices to consider
-  const cl_device_type kDeviceType = CL_DEVICE_TYPE_ALL;
-
   // Maximum number of test results printed on a single line
   static constexpr auto kResultsPerLine = size_t{64};
 
@@ -92,7 +89,7 @@ class Tester {
   Platform platform_;
   Device device_;
   Context context_;
-  CommandQueue queue_;
+  Queue queue_;
 
   // Whether or not to run the full test-suite or just a smoke test
   bool full_test_;

--- a/test/performance/client.h
+++ b/test/performance/client.h
@@ -38,11 +38,8 @@ template <typename T, typename U>
 class Client {
  public:
 
-  // Types of devices to consider
-  const cl_device_type kDeviceType = CL_DEVICE_TYPE_ALL;
-
   // Shorthand for the routine-specific functions passed to the tester
-  using Routine = std::function<StatusCode(const Arguments<U>&, const Buffers&, CommandQueue&)>;
+  using Routine = std::function<StatusCode(const Arguments<U>&, const Buffers<T>&, Queue&)>;
   using SetMetric = std::function<void(Arguments<U>&)>;
   using GetMetric = std::function<size_t(const Arguments<U>&)>;
 
@@ -63,8 +60,8 @@ class Client {
  private:
 
   // Runs a function a given number of times and returns the execution time of the shortest instance
-  double TimedExecution(const size_t num_runs, const Arguments<U> &args, const Buffers &buffers,
-                        CommandQueue &queue, Routine run_blas, const std::string &library_name);
+  double TimedExecution(const size_t num_runs, const Arguments<U> &args, const Buffers<T> &buffers,
+                        Queue &queue, Routine run_blas, const std::string &library_name);
 
   // Prints the header of a performance-data table
   void PrintTableHeader(const bool silent, const std::vector<std::string> &args);

--- a/test/routines/level1/xaxpy.h
+++ b/test/routines/level1/xaxpy.h
@@ -57,8 +57,7 @@ class TestXaxpy {
   static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Axpy(args.n, args.alpha,
@@ -70,8 +69,7 @@ class TestXaxpy {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<T> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXaxpy(args.n, args.alpha,
@@ -83,10 +81,9 @@ class TestXaxpy {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.y_size, static_cast<T>(0));
-    buffers.y_vec.ReadBuffer(queue, args.y_size*sizeof(T), result);
+    buffers.y_vec.Read(queue, args.y_size, result);
     return result;
   }
 

--- a/test/routines/level2/xgemv.h
+++ b/test/routines/level2/xgemv.h
@@ -68,8 +68,7 @@ class TestXgemv {
   static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Gemv(args.layout, args.a_transpose,
@@ -83,8 +82,7 @@ class TestXgemv {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<T> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXgemv(static_cast<clblasOrder>(args.layout),
@@ -99,10 +97,9 @@ class TestXgemv {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.y_size, static_cast<T>(0));
-    buffers.y_vec.ReadBuffer(queue, args.y_size*sizeof(T), result);
+    buffers.y_vec.Read(queue, args.y_size, result);
     return result;
   }
 

--- a/test/routines/level3/xgemm.h
+++ b/test/routines/level3/xgemm.h
@@ -70,8 +70,7 @@ class TestXgemm {
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Gemm(args.layout, args.a_transpose, args.b_transpose,
@@ -85,8 +84,7 @@ class TestXgemm {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<T> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXgemm(static_cast<clblasOrder>(args.layout),
@@ -102,10 +100,9 @@ class TestXgemm {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.c_size, static_cast<T>(0));
-    buffers.c_mat.ReadBuffer(queue, args.c_size*sizeof(T), result);
+    buffers.c_mat.Read(queue, args.c_size, result);
     return result;
   }
 

--- a/test/routines/level3/xhemm.h
+++ b/test/routines/level3/xhemm.h
@@ -70,8 +70,7 @@ class TestXhemm {
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Hemm(args.layout, args.side, args.triangle,
@@ -85,8 +84,7 @@ class TestXhemm {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<T> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXhemm(static_cast<clblasOrder>(args.layout),
@@ -102,10 +100,9 @@ class TestXhemm {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.c_size, static_cast<T>(0));
-    buffers.c_mat.ReadBuffer(queue, args.c_size*sizeof(T), result);
+    buffers.c_mat.Read(queue, args.c_size, result);
     return result;
   }
 

--- a/test/routines/level3/xher2k.h
+++ b/test/routines/level3/xher2k.h
@@ -68,8 +68,7 @@ class TestXher2k {
   static size_t DefaultLDC(const Arguments<U> &args) { return args.n; }
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<U> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<U> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto alpha2 = T{args.alpha, args.alpha};
@@ -84,8 +83,7 @@ class TestXher2k {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<U> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<U> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto alpha2 = T{args.alpha, args.alpha};
@@ -102,10 +100,9 @@ class TestXher2k {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<U> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<U> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.c_size, static_cast<T>(0));
-    buffers.c_mat.ReadBuffer(queue, args.c_size*sizeof(T), result);
+    buffers.c_mat.Read(queue, args.c_size, result);
     return result;
   }
 

--- a/test/routines/level3/xherk.h
+++ b/test/routines/level3/xherk.h
@@ -61,8 +61,7 @@ class TestXherk {
   static size_t DefaultLDC(const Arguments<U> &args) { return args.n; }
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<U> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<U> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Herk(args.layout, args.triangle, args.a_transpose,
@@ -75,8 +74,7 @@ class TestXherk {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<U> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<U> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXherk(static_cast<clblasOrder>(args.layout),
@@ -91,10 +89,9 @@ class TestXherk {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<U> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<U> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.c_size, static_cast<T>(0));
-    buffers.c_mat.ReadBuffer(queue, args.c_size*sizeof(T), result);
+    buffers.c_mat.Read(queue, args.c_size, result);
     return result;
   }
 

--- a/test/routines/level3/xsymm.h
+++ b/test/routines/level3/xsymm.h
@@ -70,8 +70,7 @@ class TestXsymm {
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Symm(args.layout, args.side, args.triangle,
@@ -85,8 +84,7 @@ class TestXsymm {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<T> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXsymm(static_cast<clblasOrder>(args.layout),
@@ -102,10 +100,9 @@ class TestXsymm {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.c_size, static_cast<T>(0));
-    buffers.c_mat.ReadBuffer(queue, args.c_size*sizeof(T), result);
+    buffers.c_mat.Read(queue, args.c_size, result);
     return result;
   }
 

--- a/test/routines/level3/xsyr2k.h
+++ b/test/routines/level3/xsyr2k.h
@@ -68,8 +68,7 @@ class TestXsyr2k {
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Syr2k(args.layout, args.triangle, args.a_transpose,
@@ -83,8 +82,7 @@ class TestXsyr2k {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<T> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXsyr2k(static_cast<clblasOrder>(args.layout),
@@ -100,10 +98,9 @@ class TestXsyr2k {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.c_size, static_cast<T>(0));
-    buffers.c_mat.ReadBuffer(queue, args.c_size*sizeof(T), result);
+    buffers.c_mat.Read(queue, args.c_size, result);
     return result;
   }
 

--- a/test/routines/level3/xsyrk.h
+++ b/test/routines/level3/xsyrk.h
@@ -61,8 +61,7 @@ class TestXsyrk {
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Syrk(args.layout, args.triangle, args.a_transpose,
@@ -75,8 +74,7 @@ class TestXsyrk {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<T> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXsyrk(static_cast<clblasOrder>(args.layout),
@@ -91,10 +89,9 @@ class TestXsyrk {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.c_size, static_cast<T>(0));
-    buffers.c_mat.ReadBuffer(queue, args.c_size*sizeof(T), result);
+    buffers.c_mat.Read(queue, args.c_size, result);
     return result;
   }
 

--- a/test/routines/level3/xtrmm.h
+++ b/test/routines/level3/xtrmm.h
@@ -61,8 +61,7 @@ class TestXtrmm {
   static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
-  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers &buffers,
-                               CommandQueue &queue) {
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = Trmm(args.layout, args.side, args.triangle, args.a_transpose, args.diagonal,
@@ -75,8 +74,7 @@ class TestXtrmm {
   }
 
   // Describes how to run the clBLAS routine (for correctness/performance comparison)
-  static StatusCode RunReference(const Arguments<T> &args, const Buffers &buffers,
-                                 CommandQueue &queue) {
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
     auto queue_plain = queue();
     auto event = cl_event{};
     auto status = clblasXtrmm(static_cast<clblasOrder>(args.layout),
@@ -93,10 +91,9 @@ class TestXtrmm {
   }
 
   // Describes how to download the results of the computation (more importantly: which buffer)
-  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers &buffers,
-                                       CommandQueue &queue) {
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
     std::vector<T> result(args.b_size, static_cast<T>(0));
-    buffers.b_mat.ReadBuffer(queue, args.b_size*sizeof(T), result);
+    buffers.b_mat.Read(queue, args.b_size, result);
     return result;
   }
 


### PR DESCRIPTION
Now using the new Claduc C++11 OpenCL header. This required a couple of changes:
* Buffers are now template with their size
* The Routine base-class is now template with its size (for the buffers)
* The database using one-time set `constexpr` values instead of raw strings for device types and vendor names