### PR TITLE
Refactored the correctness tests

### DIFF
--- a/test/correctness/routines/level1/xaxpy.cc
+++ b/test/correctness/routines/level1/xaxpy.cc
@@ -14,67 +14,18 @@
 #include "correctness/testblas.h"
 #include "routines/level1/xaxpy.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,T> tester{argc, argv, silent, name, TestXaxpy<T>::GetOptions(),
-                       TestXaxpy<T>::RunRoutine, TestXaxpy<T>::RunReference,
-                       TestXaxpy<T>::DownloadResult, TestXaxpy<T>::GetResultIndex,
-                       TestXaxpy<T>::ResultID1, TestXaxpy<T>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<T>{};
-
-  // Creates the arguments vector for the regular tests
-  auto regular_test_vector = std::vector<Arguments<T>>{};
-  for (auto &n: tester.kVectorDims) { args.n = n;
-    for (auto &x_inc: tester.kIncrements) { args.x_inc = x_inc;
-      for (auto &x_offset: tester.kOffsets) { args.x_offset = x_offset;
-        for (auto &y_inc: tester.kIncrements) { args.y_inc = y_inc;
-          for (auto &y_offset: tester.kOffsets) { args.y_offset = y_offset;
-            for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-              args.x_size = TestXaxpy<T>::GetSizeX(args);
-              args.y_size = TestXaxpy<T>::GetSizeY(args);
-              if (args.x_size<1 || args.y_size<1) { continue; }
-              regular_test_vector.push_back(args);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Creates the arguments vector for the invalid-buffer tests
-  auto invalid_test_vector = std::vector<Arguments<T>>{};
-  args.n = tester.kBufferSize;
-  args.x_inc = args.y_inc = 1;
-  args.x_offset = args.y_offset = 0;
-  for (auto &x_size: tester.kVecSizes) { args.x_size = x_size;
-    for (auto &y_size: tester.kVecSizes) { args.y_size = y_size;
-      invalid_test_vector.push_back(args);
-    }
-  }
-
-  // Runs the tests
-  const auto case_name = "default";
-  tester.TestRegular(regular_test_vector, case_name);
-  tester.TestInvalid(invalid_test_vector, case_name);
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<float>(argc, argv, false, "SAXPY");
-  clblast::RunTest<double>(argc, argv, true, "DAXPY");
-  clblast::RunTest<clblast::float2>(argc, argv, true, "CAXPY");
-  clblast::RunTest<clblast::double2>(argc, argv, true, "ZAXPY");
+  clblast::RunTests<clblast::TestXaxpy<float>, float, float>(argc, argv, false, "SAXPY");
+  clblast::RunTests<clblast::TestXaxpy<double>, double, double>(argc, argv, true, "DAXPY");
+  clblast::RunTests<clblast::TestXaxpy<float2>, float2, float2>(argc, argv, true, "CAXPY");
+  clblast::RunTests<clblast::TestXaxpy<double2>, double2, double2>(argc, argv, true, "ZAXPY");
   return 0;
 }
 

--- a/test/correctness/routines/level2/xgemv.cc
+++ b/test/correctness/routines/level2/xgemv.cc
@@ -14,85 +14,18 @@
 #include "correctness/testblas.h"
 #include "routines/level2/xgemv.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,T> tester{argc, argv, silent, name, TestXgemv<T>::GetOptions(),
-                       TestXgemv<T>::RunRoutine, TestXgemv<T>::RunReference,
-                       TestXgemv<T>::DownloadResult, TestXgemv<T>::GetResultIndex,
-                       TestXgemv<T>::ResultID1, TestXgemv<T>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<T>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &a_transpose: tester.kTransposes) { args.a_transpose = a_transpose;
-
-      // Creates the arguments vector for the regular tests
-      auto regular_test_vector = std::vector<Arguments<T>>{};
-      for (auto &m: tester.kMatrixVectorDims) { args.m = m;
-        for (auto &n: tester.kMatrixVectorDims) { args.n = n;
-          for (auto &a_ld: tester.kMatrixVectorDims) { args.a_ld = a_ld;
-            for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-              for (auto &x_inc: tester.kIncrements) { args.x_inc = x_inc;
-                for (auto &x_offset: tester.kOffsets) { args.x_offset = x_offset;
-                  for (auto &y_inc: tester.kIncrements) { args.y_inc = y_inc;
-                    for (auto &y_offset: tester.kOffsets) { args.y_offset = y_offset;
-                      for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                        for (auto &beta: tester.kBetaValues) { args.beta = beta;
-                          args.a_size = TestXgemv<T>::GetSizeA(args);
-                          args.x_size = TestXgemv<T>::GetSizeX(args);
-                          args.y_size = TestXgemv<T>::GetSizeY(args);
-                          if (args.a_size<1 || args.x_size<1 || args.y_size<1) { continue; }
-                          regular_test_vector.push_back(args);
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      // Creates the arguments vector for the invalid-buffer tests
-      auto invalid_test_vector = std::vector<Arguments<T>>{};
-      args.m = args.n = tester.kBufferSize;
-      args.a_ld = tester.kBufferSize;
-      args.x_inc = args.y_inc = 1;
-      args.a_offset = args.x_offset = args.y_offset = 0;
-      for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-        for (auto &x_size: tester.kVecSizes) { args.x_size = x_size;
-          for (auto &y_size: tester.kVecSizes) { args.y_size = y_size;
-            invalid_test_vector.push_back(args);
-          }
-        }
-      }
-
-      // Runs the tests
-      const auto case_name = ToString(layout)+" "+ToString(a_transpose);
-      tester.TestRegular(regular_test_vector, case_name);
-      tester.TestInvalid(invalid_test_vector, case_name);
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<float>(argc, argv, false, "SGEMV");
-  clblast::RunTest<double>(argc, argv, true, "DGEMV");
-  clblast::RunTest<clblast::float2>(argc, argv, true, "CGEMV");
-  clblast::RunTest<clblast::double2>(argc, argv, true, "ZGEMV");
+  clblast::RunTests<clblast::TestXgemv<float>, float, float>(argc, argv, false, "SGEMV");
+  clblast::RunTests<clblast::TestXgemv<double>, double, double>(argc, argv, true, "DGEMV");
+  clblast::RunTests<clblast::TestXgemv<float2>, float2, float2>(argc, argv, true, "CGEMV");
+  clblast::RunTests<clblast::TestXgemv<double2>, double2, double2>(argc, argv, true, "ZGEMV");
   return 0;
 }
 

--- a/test/correctness/routines/level3/xgemm.cc
+++ b/test/correctness/routines/level3/xgemm.cc
@@ -14,88 +14,18 @@
 #include "correctness/testblas.h"
 #include "routines/level3/xgemm.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,T> tester{argc, argv, silent, name, TestXgemm<T>::GetOptions(),
-                       TestXgemm<T>::RunRoutine, TestXgemm<T>::RunReference,
-                       TestXgemm<T>::DownloadResult, TestXgemm<T>::GetResultIndex,
-                       TestXgemm<T>::ResultID1, TestXgemm<T>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<T>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &a_transpose: tester.kTransposes) { args.a_transpose = a_transpose;
-      for (auto &b_transpose: tester.kTransposes) { args.b_transpose = b_transpose;
-
-        // Creates the arguments vector for the regular tests
-        auto regular_test_vector = std::vector<Arguments<T>>{};
-        for (auto &m: tester.kMatrixDims) { args.m = m;
-          for (auto &n: tester.kMatrixDims) { args.n = n;
-            for (auto &k: tester.kMatrixDims) { args.k = k;
-              for (auto &a_ld: tester.kMatrixDims) { args.a_ld = a_ld;
-                for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-                  for (auto &b_ld: tester.kMatrixDims) { args.b_ld = b_ld;
-                    for (auto &b_offset: tester.kOffsets) { args.b_offset = b_offset;
-                      for (auto &c_ld: tester.kMatrixDims) { args.c_ld = c_ld;
-                        for (auto &c_offset: tester.kOffsets) { args.c_offset = c_offset;
-                          for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                            for (auto &beta: tester.kBetaValues) { args.beta = beta;
-                              args.a_size = TestXgemm<T>::GetSizeA(args);
-                              args.b_size = TestXgemm<T>::GetSizeB(args);
-                              args.c_size = TestXgemm<T>::GetSizeC(args);
-                              if (args.a_size<1 || args.b_size<1 || args.c_size<1) { continue; }
-                              regular_test_vector.push_back(args);
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Creates the arguments vector for the invalid-buffer tests
-        auto invalid_test_vector = std::vector<Arguments<T>>{};
-        args.m = args.n = args.k = tester.kBufferSize;
-        args.a_ld = args.b_ld = args.c_ld = tester.kBufferSize;
-        args.a_offset = args.b_offset = args.c_offset = 0;
-        for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-          for (auto &b_size: tester.kMatSizes) { args.b_size = b_size;
-            for (auto &c_size: tester.kMatSizes) { args.c_size = c_size;
-              invalid_test_vector.push_back(args);
-            }
-          }
-        }
-
-        // Runs the tests
-        const auto case_name = ToString(layout)+" "+ToString(a_transpose)+" "+ToString(b_transpose);
-        tester.TestRegular(regular_test_vector, case_name);
-        tester.TestInvalid(invalid_test_vector, case_name);
-      }
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<float>(argc, argv, false, "SGEMM");
-  clblast::RunTest<double>(argc, argv, true, "DGEMM");
-  clblast::RunTest<clblast::float2>(argc, argv, true, "CGEMM");
-  clblast::RunTest<clblast::double2>(argc, argv, true, "ZGEMM");
+  clblast::RunTests<clblast::TestXgemm<float>, float, float>(argc, argv, false, "SGEMM");
+  clblast::RunTests<clblast::TestXgemm<double>, double, double>(argc, argv, true, "DGEMM");
+  clblast::RunTests<clblast::TestXgemm<float2>, float2, float2>(argc, argv, true, "CGEMM");
+  clblast::RunTests<clblast::TestXgemm<double2>, double2, double2>(argc, argv, true, "ZGEMM");
   return 0;
 }
 

--- a/test/correctness/routines/level3/xhemm.cc
+++ b/test/correctness/routines/level3/xhemm.cc
@@ -14,84 +14,16 @@
 #include "correctness/testblas.h"
 #include "routines/level3/xhemm.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,T> tester{argc, argv, silent, name, TestXhemm<T>::GetOptions(),
-                       TestXhemm<T>::RunRoutine, TestXhemm<T>::RunReference,
-                       TestXhemm<T>::DownloadResult, TestXhemm<T>::GetResultIndex,
-                       TestXhemm<T>::ResultID1, TestXhemm<T>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<T>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &side: tester.kSides) { args.side = side;
-      for (auto &triangle: tester.kTriangles) { args.triangle = triangle;
-
-        // Creates the arguments vector for the regular tests
-        auto regular_test_vector = std::vector<Arguments<T>>{};
-        for (auto &m: tester.kMatrixDims) { args.m = m;
-          for (auto &n: tester.kMatrixDims) { args.n = n;
-            for (auto &a_ld: tester.kMatrixDims) { args.a_ld = a_ld;
-              for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-                for (auto &b_ld: tester.kMatrixDims) { args.b_ld = b_ld;
-                  for (auto &b_offset: tester.kOffsets) { args.b_offset = b_offset;
-                    for (auto &c_ld: tester.kMatrixDims) { args.c_ld = c_ld;
-                      for (auto &c_offset: tester.kOffsets) { args.c_offset = c_offset;
-                        for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                          for (auto &beta: tester.kBetaValues) { args.beta = beta;
-                            args.a_size = TestXhemm<T>::GetSizeA(args);
-                            args.b_size = TestXhemm<T>::GetSizeB(args);
-                            args.c_size = TestXhemm<T>::GetSizeC(args);
-                            if (args.a_size<1 || args.b_size<1 || args.c_size<1) { continue; }
-                            regular_test_vector.push_back(args);
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Creates the arguments vector for the invalid-buffer tests
-        auto invalid_test_vector = std::vector<Arguments<T>>{};
-        args.m = args.n = tester.kBufferSize;
-        args.a_ld = args.b_ld = args.c_ld = tester.kBufferSize;
-        args.a_offset = args.b_offset = args.c_offset = 0;
-        for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-          for (auto &b_size: tester.kMatSizes) { args.b_size = b_size;
-            for (auto &c_size: tester.kMatSizes) { args.c_size = c_size;
-              invalid_test_vector.push_back(args);
-            }
-          }
-        }
-
-        // Runs the tests
-        const auto case_name = ToString(layout)+" "+ToString(side)+" "+ToString(triangle);
-        tester.TestRegular(regular_test_vector, case_name);
-        tester.TestInvalid(invalid_test_vector, case_name);
-      }
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<clblast::float2>(argc, argv, true, "CHEMM");
-  clblast::RunTest<clblast::double2>(argc, argv, true, "ZHEMM");
+  clblast::RunTests<clblast::TestXhemm<float2>, float2, float2>(argc, argv, true, "CHEMM");
+  clblast::RunTests<clblast::TestXhemm<double2>, double2, double2>(argc, argv, true, "ZHEMM");
   return 0;
 }
 

--- a/test/correctness/routines/level3/xher2k.cc
+++ b/test/correctness/routines/level3/xher2k.cc
@@ -14,86 +14,16 @@
 #include "correctness/testblas.h"
 #include "routines/level3/xher2k.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T, typename U>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,U> tester{argc, argv, silent, name, TestXher2k<T,U>::GetOptions(),
-                       TestXher2k<T,U>::RunRoutine, TestXher2k<T,U>::RunReference,
-                       TestXher2k<T,U>::DownloadResult, TestXher2k<T,U>::GetResultIndex,
-                       TestXher2k<T,U>::ResultID1, TestXher2k<T,U>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<U>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &triangle: tester.kTriangles) { args.triangle = triangle;
-      for (auto &ab_transpose: {Transpose::kNo, Transpose::kConjugate}) { // Regular transpose not a
-        args.a_transpose = ab_transpose;                                  // valid BLAS option
-        args.b_transpose = ab_transpose;
-
-        // Creates the arguments vector for the regular tests
-        auto regular_test_vector = std::vector<Arguments<U>>{};
-        for (auto &n: tester.kMatrixDims) { args.n = n;
-          for (auto &k: tester.kMatrixDims) { args.k = k;
-            for (auto &a_ld: tester.kMatrixDims) { args.a_ld = a_ld;
-              for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-                for (auto &b_ld: tester.kMatrixDims) { args.b_ld = b_ld;
-                  for (auto &b_offset: tester.kOffsets) { args.b_offset = b_offset;
-                    for (auto &c_ld: tester.kMatrixDims) { args.c_ld = c_ld;
-                      for (auto &c_offset: tester.kOffsets) { args.c_offset = c_offset;
-                        for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                          for (auto &beta: tester.kBetaValues) { args.beta = beta;
-                            args.a_size = TestXher2k<T,U>::GetSizeA(args);
-                            args.b_size = TestXher2k<T,U>::GetSizeB(args);
-                            args.c_size = TestXher2k<T,U>::GetSizeC(args);
-                            if (args.a_size<1 || args.b_size<1 || args.c_size<1) { continue; }
-                            regular_test_vector.push_back(args);
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Creates the arguments vector for the invalid-buffer tests
-        auto invalid_test_vector = std::vector<Arguments<U>>{};
-        args.n = args.k = tester.kBufferSize;
-        args.a_ld = args.b_ld = args.c_ld = tester.kBufferSize;
-        args.a_offset = args.b_offset = args.c_offset = 0;
-        for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-          for (auto &b_size: tester.kMatSizes) { args.b_size = b_size;
-            for (auto &c_size: tester.kMatSizes) { args.c_size = c_size;
-              invalid_test_vector.push_back(args);
-            }
-          }
-        }
-
-        // Runs the tests
-        const auto case_name = ToString(layout)+" "+ToString(triangle)+" "+ToString(ab_transpose);
-        tester.TestRegular(regular_test_vector, case_name);
-        tester.TestInvalid(invalid_test_vector, case_name);
-      }
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<clblast::float2,float>(argc, argv, false, "CHER2K");
-  clblast::RunTest<clblast::double2,double>(argc, argv, true, "ZHER2K");
+  clblast::RunTests<clblast::TestXher2k<float2,float>, float2, float>(argc, argv, false, "CHER2K");
+  clblast::RunTests<clblast::TestXher2k<double2,double>, double2, double>(argc, argv, true, "ZHER2K");
   return 0;
 }
 

--- a/test/correctness/routines/level3/xherk.cc
+++ b/test/correctness/routines/level3/xherk.cc
@@ -14,78 +14,16 @@
 #include "correctness/testblas.h"
 #include "routines/level3/xherk.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T, typename U>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,U> tester{argc, argv, silent, name, TestXherk<T,U>::GetOptions(),
-                       TestXherk<T,U>::RunRoutine, TestXherk<T,U>::RunReference,
-                       TestXherk<T,U>::DownloadResult, TestXherk<T,U>::GetResultIndex,
-                       TestXherk<T,U>::ResultID1, TestXherk<T,U>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<U>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &triangle: tester.kTriangles) { args.triangle = triangle;
-      for (auto &a_transpose: {Transpose::kNo, Transpose::kConjugate}) { // Regular transpose not a
-        args.a_transpose = a_transpose;                                  // valid BLAS option
-
-        // Creates the arguments vector for the regular tests
-        auto regular_test_vector = std::vector<Arguments<U>>{};
-        for (auto &n: tester.kMatrixDims) { args.n = n;
-          for (auto &k: tester.kMatrixDims) { args.k = k;
-            for (auto &a_ld: tester.kMatrixDims) { args.a_ld = a_ld;
-              for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-                for (auto &c_ld: tester.kMatrixDims) { args.c_ld = c_ld;
-                  for (auto &c_offset: tester.kOffsets) { args.c_offset = c_offset;
-                    for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                      for (auto &beta: tester.kBetaValues) { args.beta = beta;
-                        args.a_size = TestXherk<T,U>::GetSizeA(args);
-                        args.c_size = TestXherk<T,U>::GetSizeC(args);
-                        if (args.a_size<1 || args.c_size<1) { continue; }
-                        regular_test_vector.push_back(args);
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Creates the arguments vector for the invalid-buffer tests
-        auto invalid_test_vector = std::vector<Arguments<U>>{};
-        args.n = args.k = tester.kBufferSize;
-        args.a_ld = args.c_ld = tester.kBufferSize;
-        args.a_offset = args.c_offset = 0;
-        for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-          for (auto &c_size: tester.kMatSizes) { args.c_size = c_size;
-            invalid_test_vector.push_back(args);
-          }
-        }
-
-        // Runs the tests
-        const auto case_name = ToString(layout)+" "+ToString(triangle)+" "+ToString(a_transpose);
-        tester.TestRegular(regular_test_vector, case_name);
-        tester.TestInvalid(invalid_test_vector, case_name);
-      }
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<clblast::float2,float>(argc, argv, false, "CHERK");
-  clblast::RunTest<clblast::double2,double>(argc, argv, true, "ZHERK");
+  clblast::RunTests<clblast::TestXherk<float2,float>, float2, float>(argc, argv, false, "CHERK");
+  clblast::RunTests<clblast::TestXherk<double2,double>, double2, double>(argc, argv, true, "ZHERK");
   return 0;
 }
 

--- a/test/correctness/routines/level3/xsymm.cc
+++ b/test/correctness/routines/level3/xsymm.cc
@@ -14,86 +14,18 @@
 #include "correctness/testblas.h"
 #include "routines/level3/xsymm.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,T> tester{argc, argv, silent, name, TestXsymm<T>::GetOptions(),
-                       TestXsymm<T>::RunRoutine, TestXsymm<T>::RunReference,
-                       TestXsymm<T>::DownloadResult, TestXsymm<T>::GetResultIndex,
-                       TestXsymm<T>::ResultID1, TestXsymm<T>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<T>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &side: tester.kSides) { args.side = side;
-      for (auto &triangle: tester.kTriangles) { args.triangle = triangle;
-
-        // Creates the arguments vector for the regular tests
-        auto regular_test_vector = std::vector<Arguments<T>>{};
-        for (auto &m: tester.kMatrixDims) { args.m = m;
-          for (auto &n: tester.kMatrixDims) { args.n = n;
-            for (auto &a_ld: tester.kMatrixDims) { args.a_ld = a_ld;
-              for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-                for (auto &b_ld: tester.kMatrixDims) { args.b_ld = b_ld;
-                  for (auto &b_offset: tester.kOffsets) { args.b_offset = b_offset;
-                    for (auto &c_ld: tester.kMatrixDims) { args.c_ld = c_ld;
-                      for (auto &c_offset: tester.kOffsets) { args.c_offset = c_offset;
-                        for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                          for (auto &beta: tester.kBetaValues) { args.beta = beta;
-                            args.a_size = TestXsymm<T>::GetSizeA(args);
-                            args.b_size = TestXsymm<T>::GetSizeB(args);
-                            args.c_size = TestXsymm<T>::GetSizeC(args);
-                            if (args.a_size<1 || args.b_size<1 || args.c_size<1) { continue; }
-                            regular_test_vector.push_back(args);
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Creates the arguments vector for the invalid-buffer tests
-        auto invalid_test_vector = std::vector<Arguments<T>>{};
-        args.m = args.n = tester.kBufferSize;
-        args.a_ld = args.b_ld = args.c_ld = tester.kBufferSize;
-        args.a_offset = args.b_offset = args.c_offset = 0;
-        for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-          for (auto &b_size: tester.kMatSizes) { args.b_size = b_size;
-            for (auto &c_size: tester.kMatSizes) { args.c_size = c_size;
-              invalid_test_vector.push_back(args);
-            }
-          }
-        }
-
-        // Runs the tests
-        const auto case_name = ToString(layout)+" "+ToString(side)+" "+ToString(triangle);
-        tester.TestRegular(regular_test_vector, case_name);
-        tester.TestInvalid(invalid_test_vector, case_name);
-      }
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<float>(argc, argv, false, "SSYMM");
-  clblast::RunTest<double>(argc, argv, true, "DSYMM");
-  clblast::RunTest<clblast::float2>(argc, argv, true, "CSYMM");
-  clblast::RunTest<clblast::double2>(argc, argv, true, "ZSYMM");
+  clblast::RunTests<clblast::TestXsymm<float>, float, float>(argc, argv, false, "SSYMM");
+  clblast::RunTests<clblast::TestXsymm<double>, double, double>(argc, argv, true, "DSYMM");
+  clblast::RunTests<clblast::TestXsymm<float2>, float2, float2>(argc, argv, true, "CSYMM");
+  clblast::RunTests<clblast::TestXsymm<double2>, double2, double2>(argc, argv, true, "ZSYMM");
   return 0;
 }
 

--- a/test/correctness/routines/level3/xsyr2k.cc
+++ b/test/correctness/routines/level3/xsyr2k.cc
@@ -14,88 +14,18 @@
 #include "correctness/testblas.h"
 #include "routines/level3/xsyr2k.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,T> tester{argc, argv, silent, name, TestXsyr2k<T>::GetOptions(),
-                       TestXsyr2k<T>::RunRoutine, TestXsyr2k<T>::RunReference,
-                       TestXsyr2k<T>::DownloadResult, TestXsyr2k<T>::GetResultIndex,
-                       TestXsyr2k<T>::ResultID1, TestXsyr2k<T>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<T>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &triangle: tester.kTriangles) { args.triangle = triangle;
-      for (auto &ab_transpose: {Transpose::kNo, Transpose::kYes}) { // No conjugate here since it
-        args.a_transpose = ab_transpose;                            // is not supported by clBLAS
-        args.b_transpose = ab_transpose;
-
-        // Creates the arguments vector for the regular tests
-        auto regular_test_vector = std::vector<Arguments<T>>{};
-        for (auto &n: tester.kMatrixDims) { args.n = n;
-          for (auto &k: tester.kMatrixDims) { args.k = k;
-            for (auto &a_ld: tester.kMatrixDims) { args.a_ld = a_ld;
-              for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-                for (auto &b_ld: tester.kMatrixDims) { args.b_ld = b_ld;
-                  for (auto &b_offset: tester.kOffsets) { args.b_offset = b_offset;
-                    for (auto &c_ld: tester.kMatrixDims) { args.c_ld = c_ld;
-                      for (auto &c_offset: tester.kOffsets) { args.c_offset = c_offset;
-                        for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                          for (auto &beta: tester.kBetaValues) { args.beta = beta;
-                            args.a_size = TestXsyr2k<T>::GetSizeA(args);
-                            args.b_size = TestXsyr2k<T>::GetSizeB(args);
-                            args.c_size = TestXsyr2k<T>::GetSizeC(args);
-                            if (args.a_size<1 || args.b_size<1 || args.c_size<1) { continue; }
-                            regular_test_vector.push_back(args);
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Creates the arguments vector for the invalid-buffer tests
-        auto invalid_test_vector = std::vector<Arguments<T>>{};
-        args.n = args.k = tester.kBufferSize;
-        args.a_ld = args.b_ld = args.c_ld = tester.kBufferSize;
-        args.a_offset = args.b_offset = args.c_offset = 0;
-        for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-          for (auto &b_size: tester.kMatSizes) { args.b_size = b_size;
-            for (auto &c_size: tester.kMatSizes) { args.c_size = c_size;
-              invalid_test_vector.push_back(args);
-            }
-          }
-        }
-
-        // Runs the tests
-        const auto case_name = ToString(layout)+" "+ToString(triangle)+" "+ToString(ab_transpose);
-        tester.TestRegular(regular_test_vector, case_name);
-        tester.TestInvalid(invalid_test_vector, case_name);
-      }
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<float>(argc, argv, false, "SSYR2K");
-  clblast::RunTest<double>(argc, argv, true, "DSYR2K");
-  clblast::RunTest<clblast::float2>(argc, argv, true, "CSYR2K");
-  clblast::RunTest<clblast::double2>(argc, argv, true, "ZSYR2K");
+  clblast::RunTests<clblast::TestXsyr2k<float>, float, float>(argc, argv, false, "SSYR2K");
+  clblast::RunTests<clblast::TestXsyr2k<double>, double, double>(argc, argv, true, "DSYR2K");
+  clblast::RunTests<clblast::TestXsyr2k<float2>, float2, float2>(argc, argv, true, "CSYR2K");
+  clblast::RunTests<clblast::TestXsyr2k<double2>, double2, double2>(argc, argv, true, "ZSYR2K");
   return 0;
 }
 

--- a/test/correctness/routines/level3/xsyrk.cc
+++ b/test/correctness/routines/level3/xsyrk.cc
@@ -14,80 +14,18 @@
 #include "correctness/testblas.h"
 #include "routines/level3/xsyrk.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,T> tester{argc, argv, silent, name, TestXsyrk<T>::GetOptions(),
-                       TestXsyrk<T>::RunRoutine, TestXsyrk<T>::RunReference,
-                       TestXsyrk<T>::DownloadResult, TestXsyrk<T>::GetResultIndex,
-                       TestXsyrk<T>::ResultID1, TestXsyrk<T>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<T>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &triangle: tester.kTriangles) { args.triangle = triangle;
-      for (auto &a_transpose: {Transpose::kNo, Transpose::kYes}) { // No conjugate here since it
-        args.a_transpose = a_transpose;                            // is not supported by clBLAS
-
-        // Creates the arguments vector for the regular tests
-        auto regular_test_vector = std::vector<Arguments<T>>{};
-        for (auto &n: tester.kMatrixDims) { args.n = n;
-          for (auto &k: tester.kMatrixDims) { args.k = k;
-            for (auto &a_ld: tester.kMatrixDims) { args.a_ld = a_ld;
-              for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-                for (auto &c_ld: tester.kMatrixDims) { args.c_ld = c_ld;
-                  for (auto &c_offset: tester.kOffsets) { args.c_offset = c_offset;
-                    for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                      for (auto &beta: tester.kBetaValues) { args.beta = beta;
-                        args.a_size = TestXsyrk<T>::GetSizeA(args);
-                        args.c_size = TestXsyrk<T>::GetSizeC(args);
-                        if (args.a_size<1 || args.c_size<1) { continue; }
-                        regular_test_vector.push_back(args);
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Creates the arguments vector for the invalid-buffer tests
-        auto invalid_test_vector = std::vector<Arguments<T>>{};
-        args.n = args.k = tester.kBufferSize;
-        args.a_ld = args.c_ld = tester.kBufferSize;
-        args.a_offset = args.c_offset = 0;
-        for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-          for (auto &c_size: tester.kMatSizes) { args.c_size = c_size;
-            invalid_test_vector.push_back(args);
-          }
-        }
-
-        // Runs the tests
-        const auto case_name = ToString(layout)+" "+ToString(triangle)+" "+ToString(a_transpose);
-        tester.TestRegular(regular_test_vector, case_name);
-        tester.TestInvalid(invalid_test_vector, case_name);
-      }
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<float>(argc, argv, false, "SSYRK");
-  clblast::RunTest<double>(argc, argv, true, "DSYRK");
-  clblast::RunTest<clblast::float2>(argc, argv, true, "CSYRK");
-  clblast::RunTest<clblast::double2>(argc, argv, true, "ZSYRK");
+  clblast::RunTests<clblast::TestXsyrk<float>, float, float>(argc, argv, false, "SSYRK");
+  clblast::RunTests<clblast::TestXsyrk<double>, double, double>(argc, argv, true, "DSYRK");
+  clblast::RunTests<clblast::TestXsyrk<float2>, float2, float2>(argc, argv, true, "CSYRK");
+  clblast::RunTests<clblast::TestXsyrk<double2>, double2, double2>(argc, argv, true, "ZSYRK");
   return 0;
 }
 

--- a/test/correctness/routines/level3/xtrmm.cc
+++ b/test/correctness/routines/level3/xtrmm.cc
@@ -14,82 +14,18 @@
 #include "correctness/testblas.h"
 #include "routines/level3/xtrmm.h"
 
-namespace clblast {
 // =================================================================================================
 
-// The correctness tester
-template <typename T>
-void RunTest(int argc, char *argv[], const bool silent, const std::string &name) {
-
-  // Creates a tester
-  TestBlas<T,T> tester{argc, argv, silent, name, TestXtrmm<T>::GetOptions(),
-                       TestXtrmm<T>::RunRoutine, TestXtrmm<T>::RunReference,
-                       TestXtrmm<T>::DownloadResult, TestXtrmm<T>::GetResultIndex,
-                       TestXtrmm<T>::ResultID1, TestXtrmm<T>::ResultID2};
-
-  // This variable holds the arguments relevant for this routine
-  auto args = Arguments<T>{};
-
-  // Loops over the test-cases from a data-layout point of view
-  for (auto &layout: tester.kLayouts) { args.layout = layout;
-    for (auto &side: tester.kSides) { args.side = side;
-      for (auto &triangle: tester.kTriangles) { args.triangle = triangle;
-        for (auto &a_transpose: tester.kTransposes) { args.a_transpose = a_transpose;
-          for (auto &diagonal: tester.kDiagonals) { args.diagonal = diagonal;
-
-            // Creates the arguments vector for the regular tests
-            auto regular_test_vector = std::vector<Arguments<T>>{};
-            for (auto &m: tester.kMatrixDims) { args.m = m;
-              for (auto &n: tester.kMatrixDims) { args.n = n;
-                for (auto &a_ld: tester.kMatrixDims) { args.a_ld = a_ld;
-                  for (auto &a_offset: tester.kOffsets) { args.a_offset = a_offset;
-                    for (auto &b_ld: tester.kMatrixDims) { args.b_ld = b_ld;
-                      for (auto &b_offset: tester.kOffsets) { args.b_offset = b_offset;
-                        for (auto &alpha: tester.kAlphaValues) { args.alpha = alpha;
-                          args.a_size = TestXtrmm<T>::GetSizeA(args);
-                          args.b_size = TestXtrmm<T>::GetSizeB(args);
-                          if (args.a_size<1 || args.b_size<1) { continue; }
-                          regular_test_vector.push_back(args);
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-
-            // Creates the arguments vector for the invalid-buffer tests
-            auto invalid_test_vector = std::vector<Arguments<T>>{};
-            args.m = args.n = tester.kBufferSize;
-            args.a_ld = args.b_ld = tester.kBufferSize;
-            args.a_offset = args.b_offset = 0;
-            for (auto &a_size: tester.kMatSizes) { args.a_size = a_size;
-              for (auto &b_size: tester.kMatSizes) { args.b_size = b_size;
-                invalid_test_vector.push_back(args);
-              }
-            }
-
-            // Runs the tests
-            const auto case_name = ToString(layout)+" "+ToString(side)+" "+ToString(triangle)+" "+
-                                   ToString(a_transpose)+" "+ToString(diagonal);
-            tester.TestRegular(regular_test_vector, case_name);
-            tester.TestInvalid(invalid_test_vector, case_name);
-          }
-        }
-      }
-    }
-  }
-}
-
-// =================================================================================================
-} // namespace clblast
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
-  clblast::RunTest<float>(argc, argv, false, "STRMM");
-  clblast::RunTest<double>(argc, argv, true, "DTRMM");
-  clblast::RunTest<clblast::float2>(argc, argv, true, "CTRMM");
-  clblast::RunTest<clblast::double2>(argc, argv, true, "ZTRMM");
+  clblast::RunTests<clblast::TestXtrmm<float>, float, float>(argc, argv, false, "STRMM");
+  clblast::RunTests<clblast::TestXtrmm<double>, double, double>(argc, argv, true, "DTRMM");
+  clblast::RunTests<clblast::TestXtrmm<float2>, float2, float2>(argc, argv, true, "CTRMM");
+  clblast::RunTests<clblast::TestXtrmm<double2>, double2, double2>(argc, argv, true, "ZTRMM");
   return 0;
 }
 

--- a/test/correctness/testblas.h
+++ b/test/correctness/testblas.h
@@ -19,6 +19,7 @@
 
 #include <vector>
 #include <string>
+#include <algorithm>
 
 #include "correctness/tester.h"
 
@@ -98,6 +99,175 @@ class TestBlas: public Tester<T,U> {
   ResultIterator get_id1_;
   ResultIterator get_id2_;
 };
+
+// =================================================================================================
+
+// The interface to the correctness tester. This is a separate function in the header such that it
+// is automatically compiled for each routine, templated by the parameter "C".
+template <typename C, typename T, typename U>
+void RunTests(int argc, char *argv[], const bool silent, const std::string &name) {
+
+  // Creates a tester
+  auto options = C::GetOptions();
+  TestBlas<T,U> tester{argc, argv, silent, name, options, C::RunRoutine, C::RunReference,
+                       C::DownloadResult, C::GetResultIndex, C::ResultID1, C::ResultID2};
+
+  // This variable holds the arguments relevant for this routine
+  auto args = Arguments<U>{};
+
+  // Initializes the vectors with a single element. If this particular option is relevant for this
+  // routine, this vector is overridden. Otherwise, it is unused - the value here does not matter.
+  auto ms = std::vector<size_t>{args.m};
+  auto ns = std::vector<size_t>{args.n};
+  auto ks = std::vector<size_t>{args.k};
+  auto layouts = std::vector<Layout>{args.layout};
+  auto a_transposes = std::vector<Transpose>{args.a_transpose};
+  auto b_transposes = std::vector<Transpose>{args.b_transpose};
+  auto sides = std::vector<Side>{args.side};
+  auto triangles = std::vector<Triangle>{args.triangle};
+  auto diagonals = std::vector<Diagonal>{args.diagonal};
+  auto x_incs = std::vector<size_t>{args.x_inc};
+  auto y_incs = std::vector<size_t>{args.y_inc};
+  auto x_offsets = std::vector<size_t>{args.x_offset};
+  auto y_offsets = std::vector<size_t>{args.y_offset};
+  auto a_lds = std::vector<size_t>{args.a_ld};
+  auto b_lds = std::vector<size_t>{args.b_ld};
+  auto c_lds = std::vector<size_t>{args.c_ld};
+  auto a_offsets = std::vector<size_t>{args.a_offset};
+  auto b_offsets = std::vector<size_t>{args.b_offset};
+  auto c_offsets = std::vector<size_t>{args.c_offset};
+  auto alphas = std::vector<U>{args.alpha};
+  auto betas = std::vector<U>{args.beta};
+  auto x_sizes = std::vector<size_t>{args.x_size};
+  auto y_sizes = std::vector<size_t>{args.y_size};
+  auto a_sizes = std::vector<size_t>{args.a_size};
+  auto b_sizes = std::vector<size_t>{args.b_size};
+  auto c_sizes = std::vector<size_t>{args.c_size};
+
+  // Sets the dimensions of the matrices or vectors depending on the BLAS level
+  auto dimensions = (C::BLASLevel() == 3) ? tester.kMatrixDims :
+                    (C::BLASLevel() == 2) ? tester.kMatrixVectorDims :
+                    tester.kVectorDims; // else: level 1
+
+  // For the options relevant to this routine, sets the vectors to proper values
+  for (auto &option: options) {
+    if (option == kArgM) { ms = dimensions; }
+    if (option == kArgN) { ns = dimensions; }
+    if (option == kArgK) { ks = dimensions; }
+    if (option == kArgLayout) { layouts = tester.kLayouts; }
+    if (option == kArgATransp) { a_transposes = C::GetATransposes(tester.kTransposes); }
+    if (option == kArgBTransp) { b_transposes = C::GetBTransposes(tester.kTransposes); }
+    if (option == kArgSide) { sides = tester.kSides; }
+    if (option == kArgTriangle) { triangles = tester.kTriangles; }
+    if (option == kArgDiagonal) { diagonals = tester.kDiagonals; }
+    if (option == kArgXInc) { x_incs = tester.kIncrements; }
+    if (option == kArgYInc) { y_incs = tester.kIncrements; }
+    if (option == kArgXOffset) { x_offsets = tester.kOffsets; }
+    if (option == kArgYOffset) { y_offsets = tester.kOffsets; }
+    if (option == kArgALeadDim) { a_lds = dimensions; }
+    if (option == kArgBLeadDim) { b_lds = dimensions; }
+    if (option == kArgCLeadDim) { c_lds = dimensions; }
+    if (option == kArgAOffset) { a_offsets = tester.kOffsets; }
+    if (option == kArgBOffset) { b_offsets = tester.kOffsets; }
+    if (option == kArgCOffset) { c_offsets = tester.kOffsets; }
+    if (option == kArgAlpha) { alphas = tester.kAlphaValues; }
+    if (option == kArgBeta) { betas = tester.kBetaValues; }
+
+    if (option == kArgXOffset) { x_sizes = tester.kVecSizes; }
+    if (option == kArgYOffset) { y_sizes = tester.kVecSizes; }
+    if (option == kArgAOffset) { a_sizes = tester.kMatSizes; }
+    if (option == kArgBOffset) { b_sizes = tester.kMatSizes; }
+    if (option == kArgCOffset) { c_sizes = tester.kMatSizes; }
+  }
+
+  // Loops over the test-cases from a data-layout point of view
+  for (auto &layout: layouts) { args.layout = layout;
+    for (auto &a_transpose: a_transposes) { args.a_transpose = a_transpose;
+      for (auto &b_transpose: b_transposes) { args.b_transpose = b_transpose;
+        for (auto &side: sides) { args.side = side;
+          for (auto &triangle: triangles) { args.triangle = triangle;
+            for (auto &diagonal: diagonals) { args.diagonal = diagonal;
+
+              // Creates the arguments vector for the regular tests
+              auto regular_test_vector = std::vector<Arguments<U>>{};
+              auto r_args = args;
+              for (auto &m: ms) { r_args.m = m;
+                for (auto &n: ns) { r_args.n = n;
+                  for (auto &k: ks) { r_args.k = k;
+                    for (auto &x_inc: x_incs) { r_args.x_inc = x_inc;
+                      for (auto &x_offset: x_offsets) { r_args.x_offset = x_offset;
+                        for (auto &y_inc: y_incs) { r_args.y_inc = y_inc;
+                          for (auto &y_offset: y_offsets) { r_args.y_offset = y_offset;
+                            for (auto &a_ld: a_lds) { r_args.a_ld = a_ld;
+                              for (auto &a_offset: a_offsets) { r_args.a_offset = a_offset;
+                                for (auto &b_ld: b_lds) { r_args.b_ld = b_ld;
+                                  for (auto &b_offset: b_offsets) { r_args.b_offset = b_offset;
+                                    for (auto &c_ld: c_lds) { r_args.c_ld = c_ld;
+                                      for (auto &c_offset: c_offsets) { r_args.c_offset = c_offset;
+                                        for (auto &alpha: alphas) { r_args.alpha = alpha;
+                                          for (auto &beta: betas) { r_args.beta = beta;
+                                            C::SetSizes(r_args);
+                                            regular_test_vector.push_back(r_args);
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+
+              // Creates the arguments vector for the invalid-buffer tests
+              auto invalid_test_vector = std::vector<Arguments<U>>{};
+              auto i_args = args;
+              i_args.m = i_args.n = i_args.k = tester.kBufferSize;
+              i_args.a_ld = i_args.b_ld = i_args.c_ld = tester.kBufferSize;
+              for (auto &x_size: x_sizes) { i_args.x_size = x_size;
+                for (auto &y_size: y_sizes) { i_args.y_size = y_size;
+                  for (auto &a_size: a_sizes) { i_args.a_size = a_size;
+                    for (auto &b_size: b_sizes) { i_args.b_size = b_size;
+                      for (auto &c_size: c_sizes) { i_args.c_size = c_size;
+                        invalid_test_vector.push_back(i_args);
+                      }
+                    }
+                  }
+                }
+              }
+
+              // Sets the name of this test-case
+              auto names = std::vector<std::string>{};
+              for (auto &option: options) {
+                if (option == kArgLayout) { names.push_back(ToString(layout)); }
+                if (option == kArgATransp) { names.push_back(ToString(a_transpose)); }
+                if (option == kArgBTransp) { names.push_back(ToString(b_transpose)); }
+                if (option == kArgSide) { names.push_back(ToString(side)); }
+                if (option == kArgTriangle) { names.push_back(ToString(triangle)); }
+                if (option == kArgDiagonal) { names.push_back(ToString(diagonal)); }
+              }
+              if (names.size() == 0) { names.push_back("default"); }
+              auto case_name = std::string{};
+              for (auto i=size_t{0}; i<names.size(); ++i) {
+                case_name += names[i];
+                if (i != names.size()-1) { case_name += " "; }
+              }
+
+              // Runs the tests
+              tester.TestRegular(regular_test_vector, case_name);
+              tester.TestInvalid(invalid_test_vector, case_name);
+            }
+          }
+        }
+      }
+    }
+  }
+}
 
 // =================================================================================================
 } // namespace clblast

--- a/test/routines/level1/xaxpy.h
+++ b/test/routines/level1/xaxpy.h
@@ -29,6 +29,9 @@ template <typename T>
 class TestXaxpy {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 1; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgN,
@@ -55,6 +58,11 @@ class TestXaxpy {
   static size_t DefaultLDA(const Arguments<T> &) { return 1; } // N/A for this routine
   static size_t DefaultLDB(const Arguments<T> &) { return 1; } // N/A for this routine
   static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {}; } // N/A for this routine
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level2/xgemv.h
+++ b/test/routines/level2/xgemv.h
@@ -29,6 +29,9 @@ template <typename T>
 class TestXgemv {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 2; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgM, kArgN,
@@ -39,11 +42,6 @@ class TestXgemv {
   }
 
   // Describes how to obtain the sizes of the buffers
-  static size_t GetSizeA(const Arguments<T> &args) {
-    auto a_rotated = (args.layout == Layout::kRowMajor);
-    auto a_two = (a_rotated) ? args.m : args.n;
-    return a_two * args.a_ld + args.a_offset;
-  }
   static size_t GetSizeX(const Arguments<T> &args) {
     auto a_transposed = (args.a_transpose != Transpose::kNo);
     auto n_real = (a_transposed) ? args.m : args.n;
@@ -53,6 +51,11 @@ class TestXgemv {
     auto a_transposed = (args.a_transpose != Transpose::kNo);
     auto m_real = (a_transposed) ? args.n : args.m;
     return m_real * args.y_inc + args.y_offset;
+  }
+  static size_t GetSizeA(const Arguments<T> &args) {
+    auto a_rotated = (args.layout == Layout::kRowMajor);
+    auto a_two = (a_rotated) ? args.m : args.n;
+    return a_two * args.a_ld + args.a_offset;
   }
 
   // Describes how to set the sizes of all the buffers
@@ -66,6 +69,11 @@ class TestXgemv {
   static size_t DefaultLDA(const Arguments<T> &args) { return args.n; }
   static size_t DefaultLDB(const Arguments<T> &) { return 1; } // N/A for this routine
   static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &all) { return all; }
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level3/xgemm.h
+++ b/test/routines/level3/xgemm.h
@@ -29,6 +29,9 @@ template <typename T>
 class TestXgemm {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 3; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgM, kArgN, kArgK,
@@ -68,6 +71,11 @@ class TestXgemm {
   static size_t DefaultLDA(const Arguments<T> &args) { return args.k; }
   static size_t DefaultLDB(const Arguments<T> &args) { return args.n; }
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &all) { return all; }
+  static Transposes GetBTransposes(const Transposes &all) { return all; }
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level3/xhemm.h
+++ b/test/routines/level3/xhemm.h
@@ -29,6 +29,9 @@ template <typename T>
 class TestXhemm {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 3; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgM, kArgN,
@@ -68,6 +71,11 @@ class TestXhemm {
   static size_t DefaultLDA(const Arguments<T> &args) { return args.m; }
   static size_t DefaultLDB(const Arguments<T> &args) { return args.n; }
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {}; } // N/A for this routine
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level3/xher2k.h
+++ b/test/routines/level3/xher2k.h
@@ -29,6 +29,9 @@ template <typename T, typename U>
 class TestXher2k {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 3; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgN, kArgK,
@@ -46,8 +49,8 @@ class TestXher2k {
     return a_two * args.a_ld + args.a_offset;
   }
   static size_t GetSizeB(const Arguments<U> &args) {
-    auto b_rotated = (args.layout == Layout::kColMajor && args.b_transpose != Transpose::kNo) ||
-                     (args.layout == Layout::kRowMajor && args.b_transpose == Transpose::kNo);
+    auto b_rotated = (args.layout == Layout::kColMajor && args.a_transpose != Transpose::kNo) ||
+                     (args.layout == Layout::kRowMajor && args.a_transpose == Transpose::kNo);
     auto b_two = (b_rotated) ? args.n : args.k;
     return b_two * args.b_ld + args.b_offset;
   }
@@ -66,6 +69,11 @@ class TestXher2k {
   static size_t DefaultLDA(const Arguments<U> &args) { return args.k; }
   static size_t DefaultLDB(const Arguments<U> &args) { return args.k; }
   static size_t DefaultLDC(const Arguments<U> &args) { return args.n; }
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {Transpose::kNo, Transpose::kConjugate}; }
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<U> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level3/xherk.h
+++ b/test/routines/level3/xherk.h
@@ -29,6 +29,9 @@ template <typename T, typename U>
 class TestXherk {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 3; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgN, kArgK,
@@ -59,6 +62,11 @@ class TestXherk {
   static size_t DefaultLDA(const Arguments<U> &args) { return args.k; }
   static size_t DefaultLDB(const Arguments<U> &) { return 1; } // N/A for this routine
   static size_t DefaultLDC(const Arguments<U> &args) { return args.n; }
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {Transpose::kNo, Transpose::kConjugate}; }
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<U> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level3/xsymm.h
+++ b/test/routines/level3/xsymm.h
@@ -29,6 +29,9 @@ template <typename T>
 class TestXsymm {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 3; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgM, kArgN,
@@ -68,6 +71,11 @@ class TestXsymm {
   static size_t DefaultLDA(const Arguments<T> &args) { return args.m; }
   static size_t DefaultLDB(const Arguments<T> &args) { return args.n; }
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {}; } // N/A for this routine
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level3/xsyr2k.h
+++ b/test/routines/level3/xsyr2k.h
@@ -29,6 +29,9 @@ template <typename T>
 class TestXsyr2k {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 3; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgN, kArgK,
@@ -46,8 +49,8 @@ class TestXsyr2k {
     return a_two * args.a_ld + args.a_offset;
   }
   static size_t GetSizeB(const Arguments<T> &args) {
-    auto b_rotated = (args.layout == Layout::kColMajor && args.b_transpose != Transpose::kNo) ||
-                     (args.layout == Layout::kRowMajor && args.b_transpose == Transpose::kNo);
+    auto b_rotated = (args.layout == Layout::kColMajor && args.a_transpose != Transpose::kNo) ||
+                     (args.layout == Layout::kRowMajor && args.a_transpose == Transpose::kNo);
     auto b_two = (b_rotated) ? args.n : args.k;
     return b_two * args.b_ld + args.b_offset;
   }
@@ -66,6 +69,11 @@ class TestXsyr2k {
   static size_t DefaultLDA(const Arguments<T> &args) { return args.k; }
   static size_t DefaultLDB(const Arguments<T> &args) { return args.k; }
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {Transpose::kNo, Transpose::kYes}; }
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level3/xsyrk.h
+++ b/test/routines/level3/xsyrk.h
@@ -29,6 +29,9 @@ template <typename T>
 class TestXsyrk {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 3; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgN, kArgK,
@@ -59,6 +62,11 @@ class TestXsyrk {
   static size_t DefaultLDA(const Arguments<T> &args) { return args.k; }
   static size_t DefaultLDB(const Arguments<T> &) { return 1; } // N/A for this routine
   static size_t DefaultLDC(const Arguments<T> &args) { return args.n; }
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {Transpose::kNo, Transpose::kYes}; }
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {

--- a/test/routines/level3/xtrmm.h
+++ b/test/routines/level3/xtrmm.h
@@ -29,6 +29,9 @@ template <typename T>
 class TestXtrmm {
  public:
 
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 3; }
+
   // The list of arguments relevant for this routine
   static std::vector<std::string> GetOptions() {
     return {kArgM, kArgN,
@@ -59,6 +62,11 @@ class TestXtrmm {
   static size_t DefaultLDA(const Arguments<T> &args) { return args.m; }
   static size_t DefaultLDB(const Arguments<T> &args) { return args.n; }
   static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &all) { return all; }
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
 
   // Describes how to run the CLBlast routine
   static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {


### PR DESCRIPTION
Generalised the correct correctness testers of the various routines: they now all share a single function to loop over all relevant options. Behaviour is exactly as before, but code is no longer duplicated and maintainability is increased.