### PR TITLE
Level-2 routines: HEMV and SYMV

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
 Development version (next release)
 - Now using the Claduc C++11 interface to OpenCL
 - Removed clBLAS sources, it should now be installed separately for testing
+- Added level-2 routines:
+  * CHEMV/ZHEMV
+  * SSYMV/DSYMV
 
 Version 0.3.0
 - Re-organized test/client infrastructure to avoid code duplication

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ include_directories(${clblast_SOURCE_DIR}/include ${OPENCL_INCLUDE_DIRS})
 set(KERNELS copy pad transpose padtranspose xaxpy xgemv xgemm)
 set(SAMPLE_PROGRAMS sgemm)
 set(LEVEL1_ROUTINES xaxpy)
-set(LEVEL2_ROUTINES xgemv)
+set(LEVEL2_ROUTINES xgemv xsymv)
 set(LEVEL3_ROUTINES xgemm xsymm xhemm xsyrk xherk xsyr2k xher2k xtrmm)
 set(ROUTINES ${LEVEL1_ROUTINES} ${LEVEL2_ROUTINES} ${LEVEL3_ROUTINES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ include_directories(${clblast_SOURCE_DIR}/include ${OPENCL_INCLUDE_DIRS})
 set(KERNELS copy pad transpose padtranspose xaxpy xgemv xgemm)
 set(SAMPLE_PROGRAMS sgemm)
 set(LEVEL1_ROUTINES xaxpy)
-set(LEVEL2_ROUTINES xgemv xsymv)
+set(LEVEL2_ROUTINES xgemv xhemv xsymv)
 set(LEVEL3_ROUTINES xgemm xsymm xhemm xsyrk xherk xsyr2k xher2k xtrmm)
 set(ROUTINES ${LEVEL1_ROUTINES} ${LEVEL2_ROUTINES} ${LEVEL3_ROUTINES})
 

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ CLBlast is in active development and currently does not support the full set of 
 | ---------|---|---|---|---|---------|
 | xGEMV    | ✔ | ✔ | ✔ | ✔ |         |
 | xGBMV    |   |   |   |   |         |
-| xHEMV    | - | - |   |   |         |
+| xHEMV    | - | - | ✔ | ✔ |         |
 | xHBMV    | - | - |   |   |         |
 | xHPMV    | - | - |   |   |         |
-| xSYMV    |   |   | - | - |         |
+| xSYMV    | ✔ | ✔ | - | - |         |
 | xSBMV    |   |   | - | - |         |
 | xSPMV    |   |   | - | - |         |
 | xTRMV    |   |   |   |   |         |

--- a/include/clblast.h
+++ b/include/clblast.h
@@ -105,6 +105,17 @@ StatusCode Gemv(const Layout layout, const Transpose a_transpose,
                 cl_mem y_buffer, const size_t y_offset, const size_t y_inc,
                 cl_command_queue* queue, cl_event* event);
 
+// Templated-precision hermitian matrix-vector multiplication: SHEMV/DHEMV
+template <typename T>
+StatusCode Hemv(const Layout layout, const Triangle triangle,
+                const size_t n,
+                const T alpha,
+                const cl_mem a_buffer, const size_t a_offset, const size_t a_ld,
+                const cl_mem x_buffer, const size_t x_offset, const size_t x_inc,
+                const T beta,
+                cl_mem y_buffer, const size_t y_offset, const size_t y_inc,
+                cl_command_queue* queue, cl_event* event);
+
 // Templated-precision symmetric matrix-vector multiplication: SSYMV/DSYMV
 template <typename T>
 StatusCode Symv(const Layout layout, const Triangle triangle,

--- a/include/clblast.h
+++ b/include/clblast.h
@@ -105,6 +105,17 @@ StatusCode Gemv(const Layout layout, const Transpose a_transpose,
                 cl_mem y_buffer, const size_t y_offset, const size_t y_inc,
                 cl_command_queue* queue, cl_event* event);
 
+// Templated-precision symmetric matrix-vector multiplication: SSYMV/DSYMV
+template <typename T>
+StatusCode Symv(const Layout layout, const Triangle triangle,
+                const size_t n,
+                const T alpha,
+                const cl_mem a_buffer, const size_t a_offset, const size_t a_ld,
+                const cl_mem x_buffer, const size_t x_offset, const size_t x_inc,
+                const T beta,
+                cl_mem y_buffer, const size_t y_offset, const size_t y_inc,
+                cl_command_queue* queue, cl_event* event);
+
 // =================================================================================================
 // BLAS level-3 (matrix-matrix) routines
 

--- a/include/internal/routines/level2/xgemv.h
+++ b/include/internal/routines/level2/xgemv.h
@@ -36,7 +36,7 @@ class Xgemv: public Routine<T> {
   using Routine<T>::ErrorIn;
 
   // Constructor
-  Xgemv(Queue &queue, Event &event);
+  Xgemv(Queue &queue, Event &event, const std::string &name = "GEMV");
 
   // Templated-precision implementation of the routine
   StatusCode DoGemv(const Layout layout, const Transpose a_transpose,

--- a/include/internal/routines/level2/xhemv.h
+++ b/include/internal/routines/level2/xhemv.h
@@ -37,7 +37,7 @@ class Xhemv: public Xgemv<T> {
   using Xgemv<T>::DoGemv;
 
   // Constructor
-  Xhemv(Queue &queue, Event &event);
+  Xhemv(Queue &queue, Event &event, const std::string &name = "HEMV");
 
   // Templated-precision implementation of the routine
   StatusCode DoHemv(const Layout layout, const Triangle triangle,

--- a/include/internal/routines/level2/xhemv.h
+++ b/include/internal/routines/level2/xhemv.h
@@ -1,0 +1,56 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the Xhemv routine. It is based on the generalized matrix multiplication
+// routine (Xgemv). The implementation is very similar to the Xsymv routine.
+//
+// =================================================================================================
+
+#ifndef CLBLAST_ROUTINES_XHEMV_H_
+#define CLBLAST_ROUTINES_XHEMV_H_
+
+#include "internal/routines/level2/xgemv.h"
+
+namespace clblast {
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class Xhemv: public Xgemv<T> {
+ public:
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Uses the regular Xgemv routine
+  using Xgemv<T>::DoGemv;
+
+  // Constructor
+  Xhemv(Queue &queue, Event &event);
+
+  // Templated-precision implementation of the routine
+  StatusCode DoHemv(const Layout layout, const Triangle triangle,
+                    const size_t n,
+                    const T alpha,
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &x_buffer, const size_t x_offset, const size_t x_inc,
+                    const T beta,
+                    const Buffer<T> &y_buffer, const size_t y_offset, const size_t y_inc);
+};
+
+// =================================================================================================
+} // namespace clblast
+
+// CLBLAST_ROUTINES_XHEMV_H_
+#endif

--- a/include/internal/routines/level2/xsymv.h
+++ b/include/internal/routines/level2/xsymv.h
@@ -1,0 +1,58 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the Xsymv routine. It is based on the generalized mat-vec multiplication
+// routine (Xgemv). The Xsymv class inherits from the templated class Xgemv, allowing it to call the
+// "DoGemm" function directly. The "DoSymv" function first preprocesses the symmetric matrix by
+// transforming it into a general matrix, and then calls the regular GEMV code.
+//
+// =================================================================================================
+
+#ifndef CLBLAST_ROUTINES_XSYMV_H_
+#define CLBLAST_ROUTINES_XSYMV_H_
+
+#include "internal/routines/level2/xgemv.h"
+
+namespace clblast {
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class Xsymv: public Xgemv<T> {
+ public:
+
+  // Members and methods from the base class
+  using Routine<T>::db_;
+  using Routine<T>::context_;
+  using Routine<T>::GetProgramFromCache;
+  using Routine<T>::TestMatrixA;
+  using Routine<T>::RunKernel;
+  using Routine<T>::ErrorIn;
+
+  // Uses the regular Xgemv routine
+  using Xgemv<T>::DoGemv;
+
+  // Constructor
+  Xsymv(Queue &queue, Event &event);
+
+  // Templated-precision implementation of the routine
+  StatusCode DoSymv(const Layout layout, const Triangle triangle,
+                    const size_t n,
+                    const T alpha,
+                    const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                    const Buffer<T> &x_buffer, const size_t x_offset, const size_t x_inc,
+                    const T beta,
+                    const Buffer<T> &y_buffer, const size_t y_offset, const size_t y_inc);
+};
+
+// =================================================================================================
+} // namespace clblast
+
+// CLBLAST_ROUTINES_XSYMV_H_
+#endif

--- a/include/internal/routines/level2/xsymv.h
+++ b/include/internal/routines/level2/xsymv.h
@@ -39,7 +39,7 @@ class Xsymv: public Xgemv<T> {
   using Xgemv<T>::DoGemv;
 
   // Constructor
-  Xsymv(Queue &queue, Event &event);
+  Xsymv(Queue &queue, Event &event, const std::string &name = "SYMV");
 
   // Templated-precision implementation of the routine
   StatusCode DoSymv(const Layout layout, const Triangle triangle,

--- a/src/clblast.cc
+++ b/src/clblast.cc
@@ -22,6 +22,7 @@
 
 // BLAS level-2 includes
 #include "internal/routines/level2/xgemv.h"
+#include "internal/routines/level2/xhemv.h"
 #include "internal/routines/level2/xsymv.h"
 
 // BLAS level-3 includes
@@ -122,6 +123,44 @@ template StatusCode Gemv<float2>(const Layout, const Transpose,
                                  cl_command_queue*, cl_event*);
 template StatusCode Gemv<double2>(const Layout, const Transpose,
                                   const size_t, const size_t, const double2,
+                                  const cl_mem, const size_t, const size_t,
+                                  const cl_mem, const size_t, const size_t, const double2,
+                                  cl_mem, const size_t, const size_t,
+                                  cl_command_queue*, cl_event*);
+
+// =================================================================================================
+
+// HEMV
+template <typename T>
+StatusCode Hemv(const Layout layout, const Triangle triangle,
+                const size_t n, const T alpha,
+                const cl_mem a_buffer, const size_t a_offset, const size_t a_ld,
+                const cl_mem x_buffer, const size_t x_offset, const size_t x_inc, const T beta,
+                cl_mem y_buffer, const size_t y_offset, const size_t y_inc,
+                cl_command_queue* queue, cl_event* event) {
+
+  auto queue_cpp = Queue(*queue);
+  auto event_cpp = Event(*event);
+  auto routine = Xhemv<T>(queue_cpp, event_cpp);
+
+  // Compiles the routine's device kernels
+  auto status = routine.SetUp();
+  if (status != StatusCode::kSuccess) { return status; }
+
+  // Runs the routine
+  return routine.DoHemv(layout, triangle, n, alpha,
+                        Buffer<T>(a_buffer), a_offset, a_ld,
+                        Buffer<T>(x_buffer), x_offset, x_inc, beta,
+                        Buffer<T>(y_buffer), y_offset, y_inc);
+}
+template StatusCode Hemv<float2>(const Layout, const Triangle,
+                                 const size_t, const float2,
+                                 const cl_mem, const size_t, const size_t,
+                                 const cl_mem, const size_t, const size_t, const float2,
+                                 cl_mem, const size_t, const size_t,
+                                 cl_command_queue*, cl_event*);
+template StatusCode Hemv<double2>(const Layout, const Triangle,
+                                  const size_t, const double2,
                                   const cl_mem, const size_t, const size_t,
                                   const cl_mem, const size_t, const size_t, const double2,
                                   cl_mem, const size_t, const size_t,

--- a/src/kernels/xgemv.opencl
+++ b/src/kernels/xgemv.opencl
@@ -52,6 +52,63 @@ R"(
 
 // =================================================================================================
 
+// Data-widths for the 'fast' kernel
+#if VW2 == 1
+  typedef real realVF;
+#elif VW2 == 2
+  typedef real2 realVF;
+#elif VW2 == 4
+  typedef real4 realVF;
+#elif VW2 == 8
+  typedef real8 realVF;
+#elif VW2 == 16
+  typedef real16 realVF;
+#endif
+
+// Data-widths for the 'fast' kernel with rotated matrix
+#if VW3 == 1
+  typedef real realVFR;
+#elif VW3 == 2
+  typedef real2 realVFR;
+#elif VW3 == 4
+  typedef real4 realVFR;
+#elif VW3 == 8
+  typedef real8 realVFR;
+#elif VW3 == 16
+  typedef real16 realVFR;
+#endif
+
+// =================================================================================================
+// Defines how to load the input matrix in case of a symmetric matrix
+#if defined(ROUTINE_SYMV)
+
+// =================================================================================================
+// Defines how to load the input matrix in case of a hermetian matrix
+#elif defined(ROUTINE_HEMV)
+
+// =================================================================================================
+// Defines how to load the input matrix in the regular case
+#else
+
+// Loads a scalar input value
+inline real LoadMatrixA(const __global real* restrict agm, const int x, const int y,
+                        const int a_ld, const int a_offset) {
+  return agm[x + a_ld*y + a_offset];
+}
+// Loads a vector input value (1/2)
+inline realVF LoadMatrixAVF(const __global realVF* restrict agm, const int x, const int y,
+                            const int a_ld) {
+  return agm[x + a_ld*y];
+}
+// Loads a vector input value (2/2): as before, but different data-type
+inline realVFR LoadMatrixAVFR(const __global realVFR* restrict agm, const int x, const int y,
+                              const int a_ld) {
+  return agm[x + a_ld*y];
+}
+
+#endif
+// =================================================================================================
+
 // Full version of the kernel
 __attribute__((reqd_work_group_size(WGS1, 1, 1)))
 __kernel void Xgemv(const int m, const int n, const real alpha, const real beta,
@@ -96,7 +153,7 @@ __kernel void Xgemv(const int m, const int n, const real alpha, const real beta,
           #pragma unroll
           for (int kl=0; kl<WGS1; ++kl) {
             const int k = kwg + kl;
-            real value = agm[gid + a_ld*k + a_offset];
+            real value = LoadMatrixA(agm, gid, k, a_ld, a_offset);
             if (do_conjugate == 1) { COMPLEX_CONJUGATE(value); }
             MultiplyAdd(acc[w], xlm[kl], value);
           }
@@ -105,7 +162,7 @@ __kernel void Xgemv(const int m, const int n, const real alpha, const real beta,
           #pragma unroll
           for (int kl=0; kl<WGS1; ++kl) {
             const int k = kwg + kl;
-            real value = agm[k + a_ld*gid + a_offset];
+            real value = LoadMatrixA(agm, k, gid, a_ld, a_offset);
             if (do_conjugate == 1) { COMPLEX_CONJUGATE(value); }
             MultiplyAdd(acc[w], xlm[kl], value);
           }
@@ -127,7 +184,7 @@ __kernel void Xgemv(const int m, const int n, const real alpha, const real beta,
       if (a_rotated == 0) { // Not rotated
         #pragma unroll
         for (int k=n_floor; k<n; ++k) {
-          real value = agm[gid + a_ld*k + a_offset];
+          real value = LoadMatrixA(agm, gid, k, a_ld, a_offset);
           if (do_conjugate == 1) { COMPLEX_CONJUGATE(value); }
           MultiplyAdd(acc[w], xgm[k*x_inc + x_offset], value);
         }
@@ -135,7 +192,7 @@ __kernel void Xgemv(const int m, const int n, const real alpha, const real beta,
       else { // Transposed
         #pragma unroll
         for (int k=n_floor; k<n; ++k) {
-          real value = agm[k + a_ld*gid + a_offset];
+          real value = LoadMatrixA(agm, k, gid, a_ld, a_offset);
           if (do_conjugate == 1) { COMPLEX_CONJUGATE(value); }
           MultiplyAdd(acc[w], xgm[k*x_inc + x_offset], value);
         }
@@ -149,19 +206,6 @@ __kernel void Xgemv(const int m, const int n, const real alpha, const real beta,
 }
 
 // =================================================================================================
-
-// Data-widths for the 'fast' kernel
-#if VW2 == 1
-  typedef real realVF;
-#elif VW2 == 2
-  typedef real2 realVF;
-#elif VW2 == 4
-  typedef real4 realVF;
-#elif VW2 == 8
-  typedef real8 realVF;
-#elif VW2 == 16
-  typedef real16 realVF;
-#endif
 
 // Faster version of the kernel, assuming that:
 // --> 'm' and 'n' are multiples of WGS2
@@ -203,42 +247,43 @@ __kernel void XgemvFast(const int m, const int n, const real alpha, const real b
       #pragma unroll
       for (int w=0; w<WPT2/VW2; ++w) {
         const int gid = (WPT2/VW2)*get_global_id(0) + w;
+        realVF avec = LoadMatrixAVF(agm, gid, k, a_ld/VW2);
         #if VW2 == 1
-          MultiplyAdd(acc[VW2*w+0], xlm[kl], agm[gid + (a_ld/VW2)*k]);
+          MultiplyAdd(acc[VW2*w+0], xlm[kl], avec);
         #elif VW2 == 2
-          MultiplyAdd(acc[VW2*w+0], xlm[kl], agm[gid + (a_ld/VW2)*k].x);
-          MultiplyAdd(acc[VW2*w+1], xlm[kl], agm[gid + (a_ld/VW2)*k].y);
+          MultiplyAdd(acc[VW2*w+0], xlm[kl], avec.x);
+          MultiplyAdd(acc[VW2*w+1], xlm[kl], avec.y);
         #elif VW2 == 4
-          MultiplyAdd(acc[VW2*w+0], xlm[kl], agm[gid + (a_ld/VW2)*k].x);
-          MultiplyAdd(acc[VW2*w+1], xlm[kl], agm[gid + (a_ld/VW2)*k].y);
-          MultiplyAdd(acc[VW2*w+2], xlm[kl], agm[gid + (a_ld/VW2)*k].z);
-          MultiplyAdd(acc[VW2*w+3], xlm[kl], agm[gid + (a_ld/VW2)*k].w);
+          MultiplyAdd(acc[VW2*w+0], xlm[kl], avec.x);
+          MultiplyAdd(acc[VW2*w+1], xlm[kl], avec.y);
+          MultiplyAdd(acc[VW2*w+2], xlm[kl], avec.z);
+          MultiplyAdd(acc[VW2*w+3], xlm[kl], avec.w);
         #elif VW2 == 8
-          MultiplyAdd(acc[VW2*w+0], xlm[kl], agm[gid + (a_ld/VW2)*k].s0);
-          MultiplyAdd(acc[VW2*w+1], xlm[kl], agm[gid + (a_ld/VW2)*k].s1);
-          MultiplyAdd(acc[VW2*w+2], xlm[kl], agm[gid + (a_ld/VW2)*k].s2);
-          MultiplyAdd(acc[VW2*w+3], xlm[kl], agm[gid + (a_ld/VW2)*k].s3);
-          MultiplyAdd(acc[VW2*w+4], xlm[kl], agm[gid + (a_ld/VW2)*k].s4);
-          MultiplyAdd(acc[VW2*w+5], xlm[kl], agm[gid + (a_ld/VW2)*k].s5);
-          MultiplyAdd(acc[VW2*w+6], xlm[kl], agm[gid + (a_ld/VW2)*k].s6);
-          MultiplyAdd(acc[VW2*w+7], xlm[kl], agm[gid + (a_ld/VW2)*k].s7);
+          MultiplyAdd(acc[VW2*w+0], xlm[kl], avec.s0);
+          MultiplyAdd(acc[VW2*w+1], xlm[kl], avec.s1);
+          MultiplyAdd(acc[VW2*w+2], xlm[kl], avec.s2);
+          MultiplyAdd(acc[VW2*w+3], xlm[kl], avec.s3);
+          MultiplyAdd(acc[VW2*w+4], xlm[kl], avec.s4);
+          MultiplyAdd(acc[VW2*w+5], xlm[kl], avec.s5);
+          MultiplyAdd(acc[VW2*w+6], xlm[kl], avec.s6);
+          MultiplyAdd(acc[VW2*w+7], xlm[kl], avec.s7);
         #elif VW2 == 16
-          MultiplyAdd(acc[VW2*w+0], xlm[kl], agm[gid + (a_ld/VW2)*k].s0);
-          MultiplyAdd(acc[VW2*w+1], xlm[kl], agm[gid + (a_ld/VW2)*k].s1);
-          MultiplyAdd(acc[VW2*w+2], xlm[kl], agm[gid + (a_ld/VW2)*k].s2);
-          MultiplyAdd(acc[VW2*w+3], xlm[kl], agm[gid + (a_ld/VW2)*k].s3);
-          MultiplyAdd(acc[VW2*w+4], xlm[kl], agm[gid + (a_ld/VW2)*k].s4);
-          MultiplyAdd(acc[VW2*w+5], xlm[kl], agm[gid + (a_ld/VW2)*k].s5);
-          MultiplyAdd(acc[VW2*w+6], xlm[kl], agm[gid + (a_ld/VW2)*k].s6);
-          MultiplyAdd(acc[VW2*w+7], xlm[kl], agm[gid + (a_ld/VW2)*k].s7);
-          MultiplyAdd(acc[VW2*w+8], xlm[kl], agm[gid + (a_ld/VW2)*k].s8);
-          MultiplyAdd(acc[VW2*w+9], xlm[kl], agm[gid + (a_ld/VW2)*k].s9);
-          MultiplyAdd(acc[VW2*w+10], xlm[kl], agm[gid + (a_ld/VW2)*k].sA);
-          MultiplyAdd(acc[VW2*w+11], xlm[kl], agm[gid + (a_ld/VW2)*k].sB);
-          MultiplyAdd(acc[VW2*w+12], xlm[kl], agm[gid + (a_ld/VW2)*k].sC);
-          MultiplyAdd(acc[VW2*w+13], xlm[kl], agm[gid + (a_ld/VW2)*k].sD);
-          MultiplyAdd(acc[VW2*w+14], xlm[kl], agm[gid + (a_ld/VW2)*k].sE);
-          MultiplyAdd(acc[VW2*w+15], xlm[kl], agm[gid + (a_ld/VW2)*k].sF);
+          MultiplyAdd(acc[VW2*w+0], xlm[kl], avec.s0);
+          MultiplyAdd(acc[VW2*w+1], xlm[kl], avec.s1);
+          MultiplyAdd(acc[VW2*w+2], xlm[kl], avec.s2);
+          MultiplyAdd(acc[VW2*w+3], xlm[kl], avec.s3);
+          MultiplyAdd(acc[VW2*w+4], xlm[kl], avec.s4);
+          MultiplyAdd(acc[VW2*w+5], xlm[kl], avec.s5);
+          MultiplyAdd(acc[VW2*w+6], xlm[kl], avec.s6);
+          MultiplyAdd(acc[VW2*w+7], xlm[kl], avec.s7);
+          MultiplyAdd(acc[VW2*w+8], xlm[kl], avec.s8);
+          MultiplyAdd(acc[VW2*w+9], xlm[kl], avec.s9);
+          MultiplyAdd(acc[VW2*w+10], xlm[kl], avec.sA);
+          MultiplyAdd(acc[VW2*w+11], xlm[kl], avec.sB);
+          MultiplyAdd(acc[VW2*w+12], xlm[kl], avec.sC);
+          MultiplyAdd(acc[VW2*w+13], xlm[kl], avec.sD);
+          MultiplyAdd(acc[VW2*w+14], xlm[kl], avec.sE);
+          MultiplyAdd(acc[VW2*w+15], xlm[kl], avec.sF);
         #endif
       }
     }
@@ -257,19 +302,6 @@ __kernel void XgemvFast(const int m, const int n, const real alpha, const real b
 }
 
 // =================================================================================================
-
-// Data-widths for the 'fast' kernel with rotated matrix
-#if VW3 == 1
-  typedef real realVFR;
-#elif VW3 == 2
-  typedef real2 realVFR;
-#elif VW3 == 4
-  typedef real4 realVFR;
-#elif VW3 == 8
-  typedef real8 realVFR;
-#elif VW3 == 16
-  typedef real16 realVFR;
-#endif
 
 // Faster version of the kernel, assuming that:
 // --> 'm' and 'n' are multiples of WGS3
@@ -311,7 +343,7 @@ __kernel void XgemvFastRot(const int m, const int n, const real alpha, const rea
       #pragma unroll
       for (int w=0; w<WPT3; ++w) {
         const int gid = WPT3*get_global_id(0) + w;
-        realVFR avec = agm[k + (a_ld/VW3)*gid];
+        realVFR avec = LoadMatrixAVFR(agm, k, gid, a_ld/VW3);
         #if VW3 == 1
           MultiplyAdd(acc[w], xlm[VW3*kl+0], avec);
         #elif VW3 == 2

--- a/src/kernels/xgemv.opencl
+++ b/src/kernels/xgemv.opencl
@@ -79,16 +79,7 @@ R"(
 #endif
 
 // =================================================================================================
-// Defines how to load the input matrix in case of a symmetric matrix
-#if defined(ROUTINE_SYMV)
-
-// =================================================================================================
-// Defines how to load the input matrix in case of a hermetian matrix
-#elif defined(ROUTINE_HEMV)
-
-// =================================================================================================
 // Defines how to load the input matrix in the regular case
-#else
 
 // Loads a scalar input value
 inline real LoadMatrixA(const __global real* restrict agm, const int x, const int y,
@@ -106,7 +97,6 @@ inline realVFR LoadMatrixAVFR(const __global realVFR* restrict agm, const int x,
   return agm[x + a_ld*y];
 }
 
-#endif
 // =================================================================================================
 
 // Full version of the kernel

--- a/src/routines/level2/xgemv.cc
+++ b/src/routines/level2/xgemv.cc
@@ -29,8 +29,8 @@ template <> const Precision Xgemv<double2>::precision_ = Precision::kComplexDoub
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xgemv<T>::Xgemv(Queue &queue, Event &event):
-    Routine<T>(queue, event, "GEMV", {"Pad", "Xgemv"}, precision_) {
+Xgemv<T>::Xgemv(Queue &queue, Event &event, const std::string &name):
+    Routine<T>(queue, event, name, {"Pad", "Xgemv"}, precision_) {
   source_string_ =
     #include "../../kernels/pad.opencl" // For {Herm,Symm}{Upper,Lower}ToSquared (for HEMV/SYMV)
     #include "../../kernels/xgemv.opencl"

--- a/src/routines/level2/xgemv.cc
+++ b/src/routines/level2/xgemv.cc
@@ -30,8 +30,9 @@ template <> const Precision Xgemv<double2>::precision_ = Precision::kComplexDoub
 // Constructor: forwards to base class constructor
 template <typename T>
 Xgemv<T>::Xgemv(Queue &queue, Event &event):
-    Routine<T>(queue, event, "GEMV", {"Xgemv"}, precision_) {
+    Routine<T>(queue, event, "GEMV", {"Pad", "Xgemv"}, precision_) {
   source_string_ =
+    #include "../../kernels/pad.opencl" // For SymmUpperToSquared and SymmLowerToSquared (for SYMV)
     #include "../../kernels/xgemv.opencl"
   ;
 }

--- a/src/routines/level2/xgemv.cc
+++ b/src/routines/level2/xgemv.cc
@@ -32,7 +32,7 @@ template <typename T>
 Xgemv<T>::Xgemv(Queue &queue, Event &event):
     Routine<T>(queue, event, "GEMV", {"Pad", "Xgemv"}, precision_) {
   source_string_ =
-    #include "../../kernels/pad.opencl" // For SymmUpperToSquared and SymmLowerToSquared (for SYMV)
+    #include "../../kernels/pad.opencl" // For {Herm,Symm}{Upper,Lower}ToSquared (for HEMV/SYMV)
     #include "../../kernels/xgemv.opencl"
   ;
 }

--- a/src/routines/level2/xhemv.cc
+++ b/src/routines/level2/xhemv.cc
@@ -21,8 +21,8 @@ namespace clblast {
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xhemv<T>::Xhemv(Queue &queue, Event &event):
-    Xgemv<T>(queue, event) {
+Xhemv<T>::Xhemv(Queue &queue, Event &event, const std::string &name):
+    Xgemv<T>(queue, event, name) {
 }
 
 // =================================================================================================

--- a/src/routines/level2/xhemv.cc
+++ b/src/routines/level2/xhemv.cc
@@ -1,0 +1,100 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the Xhemv class (see the header for information about the class).
+//
+// =================================================================================================
+
+#include "internal/routines/level2/xhemv.h"
+
+#include <string>
+#include <vector>
+
+namespace clblast {
+// =================================================================================================
+
+// Constructor: forwards to base class constructor
+template <typename T>
+Xhemv<T>::Xhemv(Queue &queue, Event &event):
+    Xgemv<T>(queue, event) {
+}
+
+// =================================================================================================
+
+// The main routine
+template <typename T>
+StatusCode Xhemv<T>::DoHemv(const Layout layout, const Triangle triangle,
+                            const size_t n,
+                            const T alpha,
+                            const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                            const Buffer<T> &x_buffer, const size_t x_offset, const size_t x_inc,
+                            const T beta,
+                            const Buffer<T> &y_buffer, const size_t y_offset, const size_t y_inc) {
+
+  // Makes sure all dimensions are larger than zero
+  if (n == 0) { return StatusCode::kInvalidDimension; }
+
+  // Checks for validity of the squared A matrix
+  auto status = TestMatrixA(n, n, a_buffer, a_offset, a_ld, sizeof(T));
+  if (ErrorIn(status)) { return status; }
+
+  // Determines which kernel to run based on the layout (the Xgemv kernel assumes column-major as
+  // default) and on whether we are dealing with an upper or lower triangle of the hermitian matrix
+  bool is_upper = ((triangle == Triangle::kUpper && layout != Layout::kRowMajor) ||
+                   (triangle == Triangle::kLower && layout == Layout::kRowMajor));
+  auto kernel_name = (is_upper) ? "HermUpperToSquared" : "HermLowerToSquared";
+
+  // Temporary buffer for a copy of the hermitian matrix
+  try {
+    auto temp_herm = Buffer<T>(context_, n*n);
+
+    // Creates a general matrix from the hermitian matrix to be able to run the regular Xgemv
+    // routine afterwards
+    try {
+      auto& program = GetProgramFromCache();
+      auto kernel = Kernel(program, kernel_name);
+
+      // Sets the arguments for the hermitian-to-squared kernel
+      kernel.SetArgument(0, static_cast<int>(n));
+      kernel.SetArgument(1, static_cast<int>(a_ld));
+      kernel.SetArgument(2, static_cast<int>(a_offset));
+      kernel.SetArgument(3, a_buffer());
+      kernel.SetArgument(4, static_cast<int>(n));
+      kernel.SetArgument(5, static_cast<int>(n));
+      kernel.SetArgument(6, static_cast<int>(0));
+      kernel.SetArgument(7, temp_herm());
+
+      // Uses the common padding kernel's thread configuration. This is allowed, since the
+      // hermitian-to-squared kernel uses the same parameters.
+      auto global = std::vector<size_t>{Ceil(CeilDiv(n, db_["PAD_WPTX"]), db_["PAD_DIMX"]),
+                                        Ceil(CeilDiv(n, db_["PAD_WPTY"]), db_["PAD_DIMY"])};
+      auto local = std::vector<size_t>{db_["PAD_DIMX"], db_["PAD_DIMY"]};
+      status = RunKernel(kernel, global, local);
+      if (ErrorIn(status)) { return status; }
+
+      // Runs the regular Xgemv code
+      status = DoGemv(layout, Transpose::kNo, n, n, alpha,
+                      temp_herm, 0, n,
+                      x_buffer, x_offset, x_inc, beta,
+                      y_buffer, y_offset, y_inc);
+
+      // Return the status of the Xgemv routine
+      return status;
+    } catch (...) { return StatusCode::kInvalidKernel; }
+  } catch (...) { return StatusCode::kTempBufferAllocFailure; }
+}
+
+// =================================================================================================
+
+// Compiles the templated class
+template class Xhemv<float2>;
+template class Xhemv<double2>;
+
+// =================================================================================================
+} // namespace clblast

--- a/src/routines/level2/xsymv.cc
+++ b/src/routines/level2/xsymv.cc
@@ -1,0 +1,100 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the Xsymv class (see the header for information about the class).
+//
+// =================================================================================================
+
+#include "internal/routines/level2/xsymv.h"
+
+#include <string>
+#include <vector>
+
+namespace clblast {
+// =================================================================================================
+
+// Constructor: forwards to base class constructor
+template <typename T>
+Xsymv<T>::Xsymv(Queue &queue, Event &event):
+    Xgemv<T>(queue, event) {
+}
+
+// =================================================================================================
+
+// The main routine
+template <typename T>
+StatusCode Xsymv<T>::DoSymv(const Layout layout, const Triangle triangle,
+                            const size_t n,
+                            const T alpha,
+                            const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                            const Buffer<T> &x_buffer, const size_t x_offset, const size_t x_inc,
+                            const T beta,
+                            const Buffer<T> &y_buffer, const size_t y_offset, const size_t y_inc) {
+
+  // Makes sure all dimensions are larger than zero
+  if (n == 0) { return StatusCode::kInvalidDimension; }
+
+  // Checks for validity of the squared A matrix
+  auto status = TestMatrixA(n, n, a_buffer, a_offset, a_ld, sizeof(T));
+  if (ErrorIn(status)) { return status; }
+
+  // Determines which kernel to run based on the layout (the Xgemv kernel assumes column-major as
+  // default) and on whether we are dealing with an upper or lower triangle of the symmetric matrix
+  bool is_upper = ((triangle == Triangle::kUpper && layout != Layout::kRowMajor) ||
+                   (triangle == Triangle::kLower && layout == Layout::kRowMajor));
+  auto kernel_name = (is_upper) ? "SymmUpperToSquared" : "SymmLowerToSquared";
+
+  // Temporary buffer for a copy of the symmetric matrix
+  try {
+    auto temp_symm = Buffer<T>(context_, n*n);
+
+    // Creates a general matrix from the symmetric matrix to be able to run the regular Xgemv
+    // routine afterwards
+    try {
+      auto& program = GetProgramFromCache();
+      auto kernel = Kernel(program, kernel_name);
+
+      // Sets the arguments for the symmetric-to-squared kernel
+      kernel.SetArgument(0, static_cast<int>(n));
+      kernel.SetArgument(1, static_cast<int>(a_ld));
+      kernel.SetArgument(2, static_cast<int>(a_offset));
+      kernel.SetArgument(3, a_buffer());
+      kernel.SetArgument(4, static_cast<int>(n));
+      kernel.SetArgument(5, static_cast<int>(n));
+      kernel.SetArgument(6, static_cast<int>(0));
+      kernel.SetArgument(7, temp_symm());
+
+      // Uses the common padding kernel's thread configuration. This is allowed, since the
+      // symmetric-to-squared kernel uses the same parameters.
+      auto global = std::vector<size_t>{Ceil(CeilDiv(n, db_["PAD_WPTX"]), db_["PAD_DIMX"]),
+                                        Ceil(CeilDiv(n, db_["PAD_WPTY"]), db_["PAD_DIMY"])};
+      auto local = std::vector<size_t>{db_["PAD_DIMX"], db_["PAD_DIMY"]};
+      status = RunKernel(kernel, global, local);
+      if (ErrorIn(status)) { return status; }
+
+      // Runs the regular Xgemv code
+      status = DoGemv(layout, Transpose::kNo, n, n, alpha,
+                      temp_symm, 0, n,
+                      x_buffer, x_offset, x_inc, beta,
+                      y_buffer, y_offset, y_inc);
+
+      // Return the status of the Xgemv routine
+      return status;
+    } catch (...) { return StatusCode::kInvalidKernel; }
+  } catch (...) { return StatusCode::kTempBufferAllocFailure; }
+}
+
+// =================================================================================================
+
+// Compiles the templated class
+template class Xsymv<float>;
+template class Xsymv<double>;
+
+// =================================================================================================
+} // namespace clblast

--- a/src/routines/level2/xsymv.cc
+++ b/src/routines/level2/xsymv.cc
@@ -21,8 +21,8 @@ namespace clblast {
 
 // Constructor: forwards to base class constructor
 template <typename T>
-Xsymv<T>::Xsymv(Queue &queue, Event &event):
-    Xgemv<T>(queue, event) {
+Xsymv<T>::Xsymv(Queue &queue, Event &event, const std::string &name):
+    Xgemv<T>(queue, event, name) {
 }
 
 // =================================================================================================

--- a/test/correctness/routines/level2/xhemv.cc
+++ b/test/correctness/routines/level2/xhemv.cc
@@ -1,0 +1,30 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the tests for the Xhemv routine.
+//
+// =================================================================================================
+
+#include "correctness/testblas.h"
+#include "routines/level2/xhemv.h"
+
+// =================================================================================================
+
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
+
+// Main function (not within the clblast namespace)
+int main(int argc, char *argv[]) {
+  clblast::RunTests<clblast::TestXhemv<float2>, float2, float2>(argc, argv, false, "CHEMV");
+  clblast::RunTests<clblast::TestXhemv<double2>, double2, double2>(argc, argv, true, "ZHEMV");
+  return 0;
+}
+
+// =================================================================================================

--- a/test/correctness/routines/level2/xsymv.cc
+++ b/test/correctness/routines/level2/xsymv.cc
@@ -1,0 +1,26 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the tests for the Xsymv routine.
+//
+// =================================================================================================
+
+#include "correctness/testblas.h"
+#include "routines/level2/xsymv.h"
+
+// =================================================================================================
+
+// Main function (not within the clblast namespace)
+int main(int argc, char *argv[]) {
+  clblast::RunTests<clblast::TestXsymv<float>, float, float>(argc, argv, false, "SSYMV");
+  clblast::RunTests<clblast::TestXsymv<double>, double, double>(argc, argv, true, "DSYMV");
+  return 0;
+}
+
+// =================================================================================================

--- a/test/performance/routines/level2/xhemv.cc
+++ b/test/performance/routines/level2/xhemv.cc
@@ -1,0 +1,40 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the Xhemv command-line interface performance tester.
+//
+// =================================================================================================
+
+#include "performance/client.h"
+#include "routines/level2/xhemv.h"
+
+// =================================================================================================
+
+// Shortcuts to the clblast namespace
+using float2 = clblast::float2;
+using double2 = clblast::double2;
+
+// Main function (not within the clblast namespace)
+int main(int argc, char *argv[]) {
+  switch(clblast::GetPrecision(argc, argv)) {
+    case clblast::Precision::kHalf:
+      throw std::runtime_error("Unsupported precision mode");
+    case clblast::Precision::kSingle:
+      throw std::runtime_error("Unsupported precision mode");
+    case clblast::Precision::kDouble:
+      throw std::runtime_error("Unsupported precision mode");
+    case clblast::Precision::kComplexSingle:
+      clblast::RunClient<clblast::TestXhemv<float2>, float2, float2>(argc, argv); break;
+    case clblast::Precision::kComplexDouble:
+      clblast::RunClient<clblast::TestXhemv<double2>, double2, double2>(argc, argv); break;
+  }
+  return 0;
+}
+
+// =================================================================================================

--- a/test/performance/routines/level2/xsymv.cc
+++ b/test/performance/routines/level2/xsymv.cc
@@ -1,0 +1,36 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the Xsymv command-line interface performance tester.
+//
+// =================================================================================================
+
+#include "performance/client.h"
+#include "routines/level2/xsymv.h"
+
+// =================================================================================================
+
+// Main function (not within the clblast namespace)
+int main(int argc, char *argv[]) {
+  switch(clblast::GetPrecision(argc, argv)) {
+    case clblast::Precision::kHalf:
+      throw std::runtime_error("Unsupported precision mode");
+    case clblast::Precision::kSingle:
+      clblast::RunClient<clblast::TestXsymv<float>, float, float>(argc, argv); break;
+    case clblast::Precision::kDouble:
+      clblast::RunClient<clblast::TestXsymv<double>, double, double>(argc, argv); break;
+    case clblast::Precision::kComplexSingle:
+      throw std::runtime_error("Unsupported precision mode");
+    case clblast::Precision::kComplexDouble:
+      throw std::runtime_error("Unsupported precision mode");
+  }
+  return 0;
+}
+
+// =================================================================================================

--- a/test/routines/level2/xhemv.h
+++ b/test/routines/level2/xhemv.h
@@ -1,0 +1,130 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements a class with static methods to describe the Xhemv routine. Examples of
+// such 'descriptions' are how to calculate the size a of buffer or how to run the routine. These
+// static methods are used by the correctness tester and the performance tester.
+//
+// =================================================================================================
+
+#ifndef CLBLAST_TEST_ROUTINES_XHEMV_H_
+#define CLBLAST_TEST_ROUTINES_XHEMV_H_
+
+#include <vector>
+#include <string>
+
+#include "wrapper_clblas.h"
+
+namespace clblast {
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class TestXhemv {
+ public:
+
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 2; }
+
+  // The list of arguments relevant for this routine
+  static std::vector<std::string> GetOptions() {
+    return {kArgN,
+            kArgLayout, kArgTriangle,
+            kArgALeadDim, kArgXInc, kArgYInc,
+            kArgAOffset, kArgXOffset, kArgYOffset,
+            kArgAlpha, kArgBeta};
+  }
+
+  // Describes how to obtain the sizes of the buffers
+  static size_t GetSizeX(const Arguments<T> &args) {
+    return args.n * args.x_inc + args.x_offset;
+  }
+  static size_t GetSizeY(const Arguments<T> &args) {
+    return args.n * args.y_inc + args.y_offset;
+  }
+  static size_t GetSizeA(const Arguments<T> &args) {
+    return args.n * args.a_ld + args.a_offset;
+  }
+
+  // Describes how to set the sizes of all the buffers
+  static void SetSizes(Arguments<T> &args) {
+    args.a_size = GetSizeA(args);
+    args.x_size = GetSizeX(args);
+    args.y_size = GetSizeY(args);
+  }
+
+  // Describes what the default values of the leading dimensions of the matrices are
+  static size_t DefaultLDA(const Arguments<T> &args) { return args.n; }
+  static size_t DefaultLDB(const Arguments<T> &) { return 1; } // N/A for this routine
+  static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {}; } // N/A for this routine
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
+
+  // Describes how to run the CLBlast routine
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
+    auto queue_plain = queue();
+    auto event = cl_event{};
+    auto status = Hemv(args.layout, args.triangle,
+                       args.n, args.alpha,
+                       buffers.a_mat(), args.a_offset, args.a_ld,
+                       buffers.x_vec(), args.x_offset, args.x_inc, args.beta,
+                       buffers.y_vec(), args.y_offset, args.y_inc,
+                       &queue_plain, &event);
+    clWaitForEvents(1, &event);
+    return status;
+  }
+
+  // Describes how to run the clBLAS routine (for correctness/performance comparison)
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
+    auto queue_plain = queue();
+    auto event = cl_event{};
+    auto status = clblasXhemv(static_cast<clblasOrder>(args.layout),
+                              static_cast<clblasUplo>(args.triangle),
+                              args.n, args.alpha,
+                              buffers.a_mat(), args.a_offset, args.a_ld,
+                              buffers.x_vec(), args.x_offset, args.x_inc, args.beta,
+                              buffers.y_vec(), args.y_offset, args.y_inc,
+                              1, &queue_plain, 0, nullptr, &event);
+    clWaitForEvents(1, &event);
+    return static_cast<StatusCode>(status);
+  }
+
+  // Describes how to download the results of the computation (more importantly: which buffer)
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
+    std::vector<T> result(args.y_size, static_cast<T>(0));
+    buffers.y_vec.Read(queue, args.y_size, result);
+    return result;
+  }
+
+  // Describes how to compute the indices of the result buffer
+  static size_t ResultID1(const Arguments<T> &args) {
+    return args.n;
+  }
+  static size_t ResultID2(const Arguments<T> &) { return 1; } // N/A for this routine
+  static size_t GetResultIndex(const Arguments<T> &args, const size_t id1, const size_t) {
+    return id1*args.y_inc + args.y_offset;
+  }
+
+  // Describes how to compute performance metrics
+  static size_t GetFlops(const Arguments<T> &args) {
+    return 2 * args.n * args.n;
+  }
+  static size_t GetBytes(const Arguments<T> &args) {
+    return (args.n*args.n + 2*args.n + args.n) * sizeof(T);
+  }
+};
+
+// =================================================================================================
+} // namespace clblast
+
+// CLBLAST_TEST_ROUTINES_XHEMV_H_
+#endif

--- a/test/routines/level2/xsymv.h
+++ b/test/routines/level2/xsymv.h
@@ -1,0 +1,130 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements a class with static methods to describe the Xsymv routine. Examples of
+// such 'descriptions' are how to calculate the size a of buffer or how to run the routine. These
+// static methods are used by the correctness tester and the performance tester.
+//
+// =================================================================================================
+
+#ifndef CLBLAST_TEST_ROUTINES_XSYMV_H_
+#define CLBLAST_TEST_ROUTINES_XSYMV_H_
+
+#include <vector>
+#include <string>
+
+#include "wrapper_clblas.h"
+
+namespace clblast {
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class TestXsymv {
+ public:
+
+  // The BLAS level: 1, 2, or 3
+  static size_t BLASLevel() { return 2; }
+
+  // The list of arguments relevant for this routine
+  static std::vector<std::string> GetOptions() {
+    return {kArgN,
+            kArgLayout, kArgTriangle,
+            kArgALeadDim, kArgXInc, kArgYInc,
+            kArgAOffset, kArgXOffset, kArgYOffset,
+            kArgAlpha, kArgBeta};
+  }
+
+  // Describes how to obtain the sizes of the buffers
+  static size_t GetSizeX(const Arguments<T> &args) {
+    return args.n * args.x_inc + args.x_offset;
+  }
+  static size_t GetSizeY(const Arguments<T> &args) {
+    return args.n * args.y_inc + args.y_offset;
+  }
+  static size_t GetSizeA(const Arguments<T> &args) {
+    return args.n * args.a_ld + args.a_offset;
+  }
+
+  // Describes how to set the sizes of all the buffers
+  static void SetSizes(Arguments<T> &args) {
+    args.a_size = GetSizeA(args);
+    args.x_size = GetSizeX(args);
+    args.y_size = GetSizeY(args);
+  }
+
+  // Describes what the default values of the leading dimensions of the matrices are
+  static size_t DefaultLDA(const Arguments<T> &args) { return args.n; }
+  static size_t DefaultLDB(const Arguments<T> &) { return 1; } // N/A for this routine
+  static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {}; } // N/A for this routine
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
+
+  // Describes how to run the CLBlast routine
+  static StatusCode RunRoutine(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
+    auto queue_plain = queue();
+    auto event = cl_event{};
+    auto status = Symv(args.layout, args.triangle,
+                       args.n, args.alpha,
+                       buffers.a_mat(), args.a_offset, args.a_ld,
+                       buffers.x_vec(), args.x_offset, args.x_inc, args.beta,
+                       buffers.y_vec(), args.y_offset, args.y_inc,
+                       &queue_plain, &event);
+    clWaitForEvents(1, &event);
+    return status;
+  }
+
+  // Describes how to run the clBLAS routine (for correctness/performance comparison)
+  static StatusCode RunReference(const Arguments<T> &args, const Buffers<T> &buffers, Queue &queue) {
+    auto queue_plain = queue();
+    auto event = cl_event{};
+    auto status = clblasXsymv(static_cast<clblasOrder>(args.layout),
+                              static_cast<clblasUplo>(args.triangle),
+                              args.n, args.alpha,
+                              buffers.a_mat(), args.a_offset, args.a_ld,
+                              buffers.x_vec(), args.x_offset, args.x_inc, args.beta,
+                              buffers.y_vec(), args.y_offset, args.y_inc,
+                              1, &queue_plain, 0, nullptr, &event);
+    clWaitForEvents(1, &event);
+    return static_cast<StatusCode>(status);
+  }
+
+  // Describes how to download the results of the computation (more importantly: which buffer)
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
+    std::vector<T> result(args.y_size, static_cast<T>(0));
+    buffers.y_vec.Read(queue, args.y_size, result);
+    return result;
+  }
+
+  // Describes how to compute the indices of the result buffer
+  static size_t ResultID1(const Arguments<T> &args) {
+    return args.n;
+  }
+  static size_t ResultID2(const Arguments<T> &) { return 1; } // N/A for this routine
+  static size_t GetResultIndex(const Arguments<T> &args, const size_t id1, const size_t) {
+    return id1*args.y_inc + args.y_offset;
+  }
+
+  // Describes how to compute performance metrics
+  static size_t GetFlops(const Arguments<T> &args) {
+    return 2 * args.n * args.n;
+  }
+  static size_t GetBytes(const Arguments<T> &args) {
+    return (args.n*args.n + 2*args.n + args.n) * sizeof(T);
+  }
+};
+
+// =================================================================================================
+} // namespace clblast
+
+// CLBLAST_TEST_ROUTINES_XSYMV_H_
+#endif

--- a/test/wrapper_clblas.h
+++ b/test/wrapper_clblas.h
@@ -132,6 +132,34 @@ clblasStatus clblasXgemv(
                        num_queues, queues, num_wait_events, wait_events, events);
 }
 
+// Calls {clblasSsymv, clblasDsymv} with the arguments forwarded.
+clblasStatus clblasXsymv(
+  clblasOrder layout, clblasUplo triangle, size_t n, float alpha,
+  const cl_mem a_mat, size_t a_offset, size_t a_ld,
+  const cl_mem x_vec, size_t x_offset, size_t x_inc, float beta,
+  const cl_mem y_vec, size_t y_offset, size_t y_inc,
+  cl_uint num_queues, cl_command_queue *queues,
+  cl_uint num_wait_events, const cl_event *wait_events, cl_event *events) {
+    return clblasSsymv(layout, triangle, n, alpha,
+                       a_mat, a_offset, a_ld,
+                       x_vec, x_offset, static_cast<int>(x_inc), beta,
+                       y_vec, y_offset, static_cast<int>(y_inc),
+                       num_queues, queues, num_wait_events, wait_events, events);
+}
+clblasStatus clblasXsymv(
+  clblasOrder layout, clblasUplo triangle, size_t n, double alpha,
+  const cl_mem a_mat, size_t a_offset, size_t a_ld,
+  const cl_mem x_vec, size_t x_offset, size_t x_inc, double beta,
+  const cl_mem y_vec, size_t y_offset, size_t y_inc,
+  cl_uint num_queues, cl_command_queue *queues,
+  cl_uint num_wait_events, const cl_event *wait_events, cl_event *events) {
+    return clblasDsymv(layout, triangle, n, alpha,
+                       a_mat, a_offset, a_ld,
+                       x_vec, x_offset, static_cast<int>(x_inc), beta,
+                       y_vec, y_offset, static_cast<int>(y_inc),
+                       num_queues, queues, num_wait_events, wait_events, events);
+}
+
 // =================================================================================================
 // BLAS level-3 (matrix-matrix) routines
 

--- a/test/wrapper_clblas.h
+++ b/test/wrapper_clblas.h
@@ -132,6 +132,38 @@ clblasStatus clblasXgemv(
                        num_queues, queues, num_wait_events, wait_events, events);
 }
 
+// Calls {clblasChemv, clblasZhemv} with the arguments forwarded.
+clblasStatus clblasXhemv(
+  clblasOrder layout, clblasUplo triangle, size_t n, float2 alpha,
+  const cl_mem a_mat, size_t a_offset, size_t a_ld,
+  const cl_mem x_vec, size_t x_offset, size_t x_inc, float2 beta,
+  const cl_mem y_vec, size_t y_offset, size_t y_inc,
+  cl_uint num_queues, cl_command_queue *queues,
+  cl_uint num_wait_events, const cl_event *wait_events, cl_event *events) {
+    auto cl_alpha = cl_float2{{alpha.real(), alpha.imag()}};
+    auto cl_beta = cl_float2{{beta.real(), beta.imag()}};
+    return clblasChemv(layout, triangle, n, cl_alpha,
+                       a_mat, a_offset, a_ld,
+                       x_vec, x_offset, static_cast<int>(x_inc), cl_beta,
+                       y_vec, y_offset, static_cast<int>(y_inc),
+                       num_queues, queues, num_wait_events, wait_events, events);
+}
+clblasStatus clblasXhemv(
+  clblasOrder layout, clblasUplo triangle, size_t n, double2 alpha,
+  const cl_mem a_mat, size_t a_offset, size_t a_ld,
+  const cl_mem x_vec, size_t x_offset, size_t x_inc, double2 beta,
+  const cl_mem y_vec, size_t y_offset, size_t y_inc,
+  cl_uint num_queues, cl_command_queue *queues,
+  cl_uint num_wait_events, const cl_event *wait_events, cl_event *events) {
+    auto cl_alpha = cl_double2{{alpha.real(), alpha.imag()}};
+    auto cl_beta = cl_double2{{beta.real(), beta.imag()}};
+    return clblasZhemv(layout, triangle, n, cl_alpha,
+                       a_mat, a_offset, a_ld,
+                       x_vec, x_offset, static_cast<int>(x_inc), cl_beta,
+                       y_vec, y_offset, static_cast<int>(y_inc),
+                       num_queues, queues, num_wait_events, wait_events, events);
+}
+
 // Calls {clblasSsymv, clblasDsymv} with the arguments forwarded.
 clblasStatus clblasXsymv(
   clblasOrder layout, clblasUplo triangle, size_t n, float alpha,


### PR DESCRIPTION
Added level-2 routines:
  * CHEMV/ZHEMV
  * SSYMV/DSYMV

Note: performance is not yet optimal for these routines yet, as they use a pre-processing symmetric-to-regular or hermetian-to-regular kernel and then run the regular GEMV routine. For level-3 routines this works fine, as the overhead is small compared to GEMM. Compared to GEMV it is not: memory bandwidth is scarce.