### PR TITLE
Added Travis continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
     - g++-4.8
     - clang
     - cmake
-    - fglrx
+    - fglrx=2:8.960-0ubuntu1
     - opencl-headers
 before_script:
   - mkdir install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+
+compiler:
+  - gcc
+
+before_script:
+  - cd ${TRAVIS_BUILD_DIR}
+  - mkdir build
+  - mkdir install
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH=../install ..
+
+script: 
+  - make install
+  - export PATH=${TRAVIS_BUILD_DIR}/install/bin:${PATH}
+  - export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/install/lib64:${LD_LIBRARY_PATH}
+
+after_success:
+  - which test_xgemm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 compiler:
   - gcc
+  - clang
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 addons:
@@ -13,19 +14,18 @@ addons:
     - g++-4.8
     - clang
     - cmake
+    - fglrx
+    - opencl-headers
 before_script:
-  - cd ${TRAVIS_BUILD_DIR}
-  - mkdir build
   - mkdir install
+  - export PATH=`pwd`/install/bin:${PATH}
+  - export LD_LIBRARY_PATH=`pwd`/install/lib64:`pwd`/install/lib:${LD_LIBRARY_PATH}
+  - mkdir build
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX:PATH=../install ..
 script:
   - make
   - make install
-  - export PATH=${TRAVIS_BUILD_DIR}/install/bin:${PATH}
-  - export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/install/lib64:${LD_LIBRARY_PATH}
-after_success:
-  - which test_xgemm
 notifications:
   email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,15 @@ language: cpp
 compiler:
   - gcc
   - clang
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository -y ppa:kalakris/cmake
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq gcc-4.8 g++-4.8 clang
+  - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers
+  - sudo apt-get install -qq cmake
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - kalakris-cmake
-    packages:
-    - gcc-4.8
-    - g++-4.8
-    - clang
-    - cmake
-    - fglrx=2:8.960-0ubuntu1
-    - opencl-headers
 before_script:
   - mkdir install
   - export PATH=`pwd`/install/bin:${PATH}
@@ -28,4 +23,3 @@ script:
   - make install
 notifications:
   email: false
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,31 @@
 language: cpp
-
 compiler:
   - gcc
-
+install:
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - kalakris-cmake
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - clang
+    - cmake
 before_script:
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir build
   - mkdir install
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX:PATH=../install ..
-
-script: 
+script:
+  - make
   - make install
   - export PATH=${TRAVIS_BUILD_DIR}/install/bin:${PATH}
   - export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/install/lib64:${LD_LIBRARY_PATH}
-
 after_success:
   - which test_xgemm
+notifications:
+  email: false
+sudo: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 CLBlast: The tuned OpenCL BLAS library
 ================
 
+[![Build Status](https://travis-ci.org/CNugteren/CLBlast.svg?branch=master)](https://travis-ci.org/CNugteren/CLBlast)
+
 CLBlast is a modern, lightweight, performant and tunable OpenCL BLAS library written in C++11. It is designed to leverage the full performance potential of a wide variety of OpenCL devices from different vendors, including desktop and laptop GPUs, embedded GPUs, and other accelerators. CLBlast implements BLAS routines: basic linear algebra subprograms operating on vectors and matrices.
 
 __Note that the CLBlast library is actively being developed, and is not mature enough for production environments__. This preview-version doesn't support all routines yet: others will be added in due time. It also lacks extensive tuning on some common OpenCL platforms: __out-of-the-box performance on some devices might be poor__. See below for more details.


### PR DESCRIPTION
Added an initial `.travis.yml` file to add automatic build testing using Travis CI. For now this tests only the library itself (using GCC 4.8 and Clang 3.4), not the tuners or the performance/correctness tests.