### PR TITLE
Locate the C BLAS library before the F77 one.

### DIFF
--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -48,7 +48,7 @@ mark_as_advanced(CBLAS_INCLUDE_DIRS)
 
 # Finds the library
 find_library(CBLAS_LIBRARIES
-  NAMES blas cblas mkl blis openblas accelerate
+  NAMES cblas blas mkl blis openblas accelerate
   HINTS ${CBLAS_HINTS}
   PATH_SUFFIXES
     lib lib64 lib/x86_64 lib/x64 lib/x86 lib/Win32 lib/import lib64/import


### PR DESCRIPTION
On my Chromebook 2 with Gentoo Linux, the following packages are available:
```
*  sci-libs/blas-reference
      Latest version available: 20070226-r4
      Latest version installed: 20070226-r4
      Size of files: 5208 KiB
      Homepage:      http://www.netlib.org/blas/
      Description:   Basic Linear Algebra Subprograms F77 reference implementations
      License:       BSD

*  sci-libs/cblas-reference
      Latest version available: 20030223-r6
      Latest version installed: 20030223-r6
      Size of files: 194 KiB
      Homepage:      http://www.netlib.org/blas/
      Description:   C wrapper interface to the F77 reference BLAS implementation
      License:       public-domain
```
I have changed the order of the first two library names in `cmake/Modules/FindCBLAS.cmake`:
```
-  NAMES blas cblas mkl blis openblas accelerate
+  NAMES cblas blas mkl blis openblas accelerate
```
This  allows CMake to locate the reference C BLAS library (`/usr/lib/libcblas.so`) before the F77 one (`/usr/lib/libblas.so`), and thus solves the linking issue I reported in #41 (for which I should now be able to provide more information).
