### PR TITLE
Make sure the passed types are large enough.

### DIFF
--- a/src/clpp11.hpp
+++ b/src/clpp11.hpp
@@ -194,7 +194,7 @@ class Device {
   }
   size_t MaxWorkGroupSize() const { return GetInfo<size_t>(CL_DEVICE_MAX_WORK_GROUP_SIZE); }
   size_t MaxWorkItemDimensions() const {
-    return GetInfo(CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS);
+    return GetInfo<cl_uint>(CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS);
   }
   std::vector<size_t> MaxWorkItemSizes() const {
     return GetInfoVector<size_t>(CL_DEVICE_MAX_WORK_ITEM_SIZES);
@@ -205,8 +205,8 @@ class Device {
   std::string Capabilities() const { return GetInfoString(CL_DEVICE_EXTENSIONS); }
   size_t CoreClock() const { return GetInfo(CL_DEVICE_MAX_CLOCK_FREQUENCY); }
   size_t ComputeUnits() const { return GetInfo(CL_DEVICE_MAX_COMPUTE_UNITS); }
-  size_t MemorySize() const { return GetInfo(CL_DEVICE_GLOBAL_MEM_SIZE); }
-  size_t MaxAllocSize() const { return GetInfo(CL_DEVICE_MAX_MEM_ALLOC_SIZE); }
+  size_t MemorySize() const { return GetInfo<cl_ulong>(CL_DEVICE_GLOBAL_MEM_SIZE); }
+  size_t MaxAllocSize() const { return GetInfo<cl_ulong>(CL_DEVICE_MAX_MEM_ALLOC_SIZE); }
   size_t MemoryClock() const { return 0; } // Not exposed in OpenCL
   size_t MemoryBusWidth() const { return 0; } // Not exposed in OpenCL
 
@@ -250,7 +250,7 @@ class Device {
   size_t GetInfo(const cl_device_info info) const {
     auto bytes = size_t{0};
     CheckError(clGetDeviceInfo(device_, info, 0, nullptr, &bytes));
-    auto result = cl_uint(0);
+    auto result = cl_ulong(0);
     CheckError(clGetDeviceInfo(device_, info, bytes, &result, nullptr));
     return static_cast<size_t>(result);
   }


### PR DESCRIPTION
Make sure all out parameters that are passed to functions such as clGetDeviceInfo are large enough to contain the replies.

Also make the default of GetInfo an ulong, though it's worth considering removing the non-templated function here, as it's prone to exactly these kind of errors.