### PR TITLE
Groundwork for device-specific routines (retry)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CFLAGS}")
 # ==================================================================================================
 
 # Package scripts location
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${clblast_SOURCE_DIR}/cmake/Modules/")
 
 # Requires OpenCL. It is found through the included "FindOpenCL.cmake" in CMAKE_MODULE_PATH.
 find_package(OpenCL REQUIRED)

--- a/src/clpp11.hpp
+++ b/src/clpp11.hpp
@@ -109,7 +109,9 @@ class Event {
 
   // Accessor to the private data-member
   cl_event& operator()() { return *event_; }
+  const cl_event& operator()() const { return *event_; }
   cl_event* pointer() { return &(*event_); }
+  const cl_event* pointer() const { return &(*event_); }
  private:
   std::shared_ptr<cl_event> event_;
 };
@@ -686,7 +688,7 @@ class Kernel {
   // As above, but with an event waiting list
   void Launch(const Queue &queue, const std::vector<size_t> &global,
               const std::vector<size_t> &local, EventPointer event,
-              std::vector<Event>& waitForEvents) {
+              const std::vector<Event> &waitForEvents) {
     if (waitForEvents.size() == 0) { return Launch(queue, global, local, event); }
 
     // Builds a plain version of the events waiting list

--- a/src/clpp11.hpp
+++ b/src/clpp11.hpp
@@ -689,13 +689,13 @@ class Kernel {
   void Launch(const Queue &queue, const std::vector<size_t> &global,
               const std::vector<size_t> &local, EventPointer event,
               const std::vector<Event> &waitForEvents) {
-    if (waitForEvents.size() == 0) { return Launch(queue, global, local, event); }
-
     // Builds a plain version of the events waiting list
     auto waitForEventsPlain = std::vector<cl_event>();
     for (auto &waitEvent : waitForEvents) {
-      waitForEventsPlain.push_back(waitEvent());
+      if (waitEvent()) { waitForEventsPlain.push_back(waitEvent()); }
     }
+
+    if (waitForEvents.size() == 0) { return Launch(queue, global, local, event); }
 
     // Launches the kernel while waiting for other events
     CheckError(clEnqueueNDRangeKernel(queue(), *kernel_, static_cast<cl_uint>(global.size()),

--- a/src/clpp11.hpp
+++ b/src/clpp11.hpp
@@ -695,21 +695,12 @@ class Kernel {
       if (waitEvent()) { waitForEventsPlain.push_back(waitEvent()); }
     }
 
-    if (waitForEvents.size() == 0) { return Launch(queue, global, local, event); }
-
     // Launches the kernel while waiting for other events
     CheckError(clEnqueueNDRangeKernel(queue(), *kernel_, static_cast<cl_uint>(global.size()),
-                                      nullptr, global.data(), local.data(),
+                                      nullptr, global.data(), !local.empty() ? local.data() : nullptr,
                                       static_cast<cl_uint>(waitForEventsPlain.size()),
-                                      waitForEventsPlain.data(),
+                                      !waitForEventsPlain.empty() ? waitForEventsPlain.data() : nullptr,
                                       event));
-  }
-
-  // As above, but with the default local workgroup size
-  void Launch(const Queue &queue, const std::vector<size_t> &global, EventPointer event) {
-    CheckError(clEnqueueNDRangeKernel(queue(), *kernel_, static_cast<cl_uint>(global.size()),
-                                      nullptr, global.data(), nullptr,
-                                      0, nullptr, event));
   }
 
   // Accessor to the private data-member

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -32,6 +32,7 @@ class Database {
 
   // Type alias for the database parameters
   using Parameters = std::unordered_map<std::string,size_t>;
+  using ParametersPtr = const Parameters*;
 
   // Structures for content inside the database
   struct DatabaseDevice {
@@ -78,9 +79,9 @@ class Database {
   static const DatabaseEntry PadtransposeHalf, PadtransposeSingle, PadtransposeDouble, PadtransposeComplexSingle, PadtransposeComplexDouble;
   static const std::vector<DatabaseEntry> database;
 
-  // The constructor
+  // The constructor with a user-provided database overlay
   explicit Database(const Queue &queue, const std::vector<std::string> &routines,
-                    const Precision precision);
+                    const Precision precision, const std::vector<DatabaseEntry> &overlay);
 
   // Accessor of values by key
   size_t operator[](const std::string key) const { return parameters_.find(key)->second; }
@@ -92,6 +93,11 @@ class Database {
   Parameters Search(const std::string &this_kernel, const std::string &this_type,
                     const std::string &this_vendor, const std::string &this_device,
                     const Precision this_precision) const;
+
+  // Alternate search method in a specified database, returning pointer (possibly NULL)
+  ParametersPtr Search(const std::string &this_kernel, const std::string &this_type,
+                       const std::string &this_vendor, const std::string &this_device,
+                       const Precision this_precision, const std::vector<DatabaseEntry> &db) const;
 
   // Found parameters suitable for this device/kernel
   Parameters parameters_;

--- a/src/routine.cpp
+++ b/src/routine.cpp
@@ -22,7 +22,8 @@ namespace clblast {
 
 // Constructor: not much here, because no status codes can be returned
 Routine::Routine(Queue &queue, EventPointer event, const std::string &name,
-                 const std::vector<std::string> &routines, const Precision precision):
+                 const std::vector<std::string> &routines, const Precision precision,
+                 const std::vector<Database::DatabaseEntry> &userDatabase):
     precision_(precision),
     routine_name_(name),
     queue_(queue),
@@ -30,7 +31,7 @@ Routine::Routine(Queue &queue, EventPointer event, const std::string &name,
     context_(queue_.GetContext()),
     device_(queue_.GetDevice()),
     device_name_(device_.Name()),
-    db_(queue_, routines, precision_) {
+    db_(queue_, routines, precision_, userDatabase) {
 }
 
 // =================================================================================================

--- a/src/routine.hpp
+++ b/src/routine.hpp
@@ -34,7 +34,8 @@ class Routine {
 
   // Base class constructor
   explicit Routine(Queue &queue, EventPointer event, const std::string &name,
-                   const std::vector<std::string> &routines, const Precision precision);
+                   const std::vector<std::string> &routines, const Precision precision,
+                   const std::vector<Database::DatabaseEntry> &userDatabase = {});
 
   // Set-up phase of the kernel
   StatusCode SetUp();

--- a/src/routines/common.cpp
+++ b/src/routines/common.cpp
@@ -22,7 +22,7 @@ namespace clblast {
 // Enqueues a kernel, waits for completion, and checks for errors
 StatusCode RunKernel(Kernel &kernel, Queue &queue, const Device &device,
                      std::vector<size_t> global, const std::vector<size_t> &local,
-                     EventPointer event, std::vector<Event>& waitForEvents) {
+                     EventPointer event, const std::vector<Event> &waitForEvents) {
 
   // Tests for validity of the local thread sizes
   if (local.size() > device.MaxWorkItemDimensions()) {

--- a/src/routines/common.hpp
+++ b/src/routines/common.hpp
@@ -29,12 +29,7 @@ namespace clblast {
 // Enqueues a kernel, waits for completion, and checks for errors
 StatusCode RunKernel(Kernel &kernel, Queue &queue, const Device &device,
                      std::vector<size_t> global, const std::vector<size_t> &local,
-                     EventPointer event, const std::vector<Event> &waitForEvents);
-
-// As above, but without an event waiting list
-StatusCode RunKernel(Kernel &kernel, Queue &queue, const Device &device,
-                     std::vector<size_t> global, const std::vector<size_t> &local,
-                     EventPointer event);
+                     EventPointer event, const std::vector<Event> &waitForEvents = {});
 
 // =================================================================================================
 

--- a/src/routines/common.hpp
+++ b/src/routines/common.hpp
@@ -29,7 +29,7 @@ namespace clblast {
 // Enqueues a kernel, waits for completion, and checks for errors
 StatusCode RunKernel(Kernel &kernel, Queue &queue, const Device &device,
                      std::vector<size_t> global, const std::vector<size_t> &local,
-                     EventPointer event, std::vector<Event>& waitForEvents);
+                     EventPointer event, const std::vector<Event> &waitForEvents);
 
 // As above, but without an event waiting list
 StatusCode RunKernel(Kernel &kernel, Queue &queue, const Device &device,
@@ -43,7 +43,7 @@ StatusCode RunKernel(Kernel &kernel, Queue &queue, const Device &device,
 template <typename T>
 StatusCode PadCopyTransposeMatrix(Queue &queue, const Device &device,
                                   const Database &db,
-                                  EventPointer event, std::vector<Event>& waitForEvents,
+                                  EventPointer event, const std::vector<Event> &waitForEvents,
                                   const size_t src_one, const size_t src_two,
                                   const size_t src_ld, const size_t src_offset,
                                   const Buffer<T> &src,


### PR DESCRIPTION
This pull request lays a bit of groundwork for adding support and infrastructure for device-specific routines and kernels in CLBlast (as discussed with @psyhtest and exemplified by the [Mali-optimized sgemm routine](http://malideveloper.arm.com/downloads/OpenCL/example_codes/sgemm/)).

Right now these changes facilitate creating "overlay" device-specific libraries (which are linked on top of CLBlast and implement a subset of its routines with same API/ABI). An example of such library can be seen in [intelfx/CLBlast#mali-overlay](https://github.com/intelfx/CLBlast/tree/mali-overlay).

Doing these things is certainly possible without merging this PR ([intelfx/CLBlast#mali-hackish](https://github.com/intelfx/CLBlast/tree/mali-hackish) links with unmodified CLBlast master), but it required me to ~~add insult to injury~~violate ODR a couple of times in an unsafe way by monkey-patching existing CLBlast classes, so I thought I'd better factor out the changes to existing API, so that overlay library will contain only the routine class itself.

Actually, this is not final, so this may or may not be merged. E. g. the xgemm routine changes are there just to make it easier to modify that function for device-specific needs, and similar generalizations probably should be applied to every routine out there. Also there are a couple of unrelated (yet useful) changes.

In the near future, I intend to expand this into a full-featured API for replacing parts of CLBlast in runtime without playing games with the linker and happily violating ODR in the process.