### PR TITLE
CMakeLists.txt: provide a find_package() config for dependent projects

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   global:
-    CLBLAST_ROOT: "%APPVEYOR_BUILD_FOLDER%\\bin\\clblast"
+    CLBLAST_ROOT: "%APPVEYOR_BUILD_FOLDER%\\..\\bin\\clblast"
     OPENCL_REGISTRY: "https://www.khronos.org/registry/cl"
-    OPENCL_ROOT: "%APPVEYOR_BUILD_FOLDER%\\bin\\opencl"
+    OPENCL_ROOT: "%APPVEYOR_BUILD_FOLDER%\\..\\bin\\opencl"
 
 platform:
   - x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,49 +17,21 @@ addons:
       - kubuntu-backports
     packages:
       - cmake
+      - ocl-icd-opencl-dev
 
 env:
   global:
     - CLBLAST_ROOT=${TRAVIS_BUILD_DIR}/bin/clblast
-    - OPENCL_REGISTRY=https://www.khronos.org/registry/cl
-    - OPENCL_ROOT=${TRAVIS_BUILD_DIR}/bin/opencl
 
 before_install:
   - cmake --version;
   - ${CC} --version;
   - ${CXX} --version;
 
-install:
-  # The following linux logic is necessary because of Travis's move to the GCE platform, which does not
-  # currently contain packages for fglrx: https://github.com/travis-ci/travis-ci/issues/5221
-  # We build our own linkable .so file
-  - if [ ${TRAVIS_OS_NAME} == "linux" ]; then
-      mkdir -p ${OPENCL_ROOT};
-      pushd ${OPENCL_ROOT};
-      travis_retry git clone --depth 1 https://github.com/KhronosGroup/OpenCL-ICD-Loader.git;
-      mv ./OpenCL-ICD-Loader/* .;
-      travis_retry git clone --depth 1 https://github.com/KhronosGroup/OpenCL-Headers.git inc/CL;
-      pushd inc/CL;
-      travis_retry wget -w 1 -np -nd -nv -A h,hpp ${OPENCL_REGISTRY}/api/2.1/cl.hpp;
-      popd;
-      mkdir -p lib;
-      pushd lib;
-      cmake -G "Unix Makefiles" ..;
-      make;
-      cp ./bin/libOpenCL.so .;
-      popd;
-      pushd inc/CL;
-      travis_retry git fetch origin opencl12:opencl12;
-      git checkout opencl12;
-      popd;
-      mv inc/ include/;
-      popd;
-    fi
-
 before_script:
   - mkdir -p ${CLBLAST_ROOT}
   - pushd ${CLBLAST_ROOT}
-  - cmake -DOPENCL_ROOT=${OPENCL_ROOT} -DTESTS=ON -DCLIENTS=ON ${TRAVIS_BUILD_DIR}
+  - cmake -DTESTS=ON -DCLIENTS=ON ${TRAVIS_BUILD_DIR}
 
 script:
   - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,11 +127,6 @@ endif()
 
 # ==================================================================================================
 
-# Includes directories: CLBlast and OpenCL
-include_directories(${clblast_SOURCE_DIR}/include ${clblast_SOURCE_DIR}/src ${OPENCL_INCLUDE_DIRS})
-
-# ==================================================================================================
-
 # Sets the supported routines and the used kernels. New routines and kernels should be added here.
 set(KERNELS copy_fast copy_pad transpose_fast transpose_pad xaxpy xdot xger xgemm xgemv)
 set(SAMPLE_PROGRAMS_CPP sgemm)
@@ -173,16 +168,26 @@ endforeach()
 add_library(clblast SHARED ${SOURCES})
 target_link_libraries(clblast ${OPENCL_LIBRARIES})
 
+# Includes directories: CLBlast and OpenCL
+target_include_directories(clblast PUBLIC
+                           $<BUILD_INTERFACE:${clblast_SOURCE_DIR}/include>
+                           $<BUILD_INTERFACE:${clblast_SOURCE_DIR}/src>
+                           $<INSTALL_INTERFACE:include>
+                           ${OPENCL_INCLUDE_DIRS})
+
 # Sets the proper __declspec(dllexport) keyword for Visual Studio when the library is built
 if(MSVC)
   target_compile_definitions(clblast PRIVATE COMPILING_DLL=1) # requires at least CMake 2.8.11
 endif()
 
 # Installs the library
-install(TARGETS clblast DESTINATION lib)
+install(TARGETS clblast EXPORT CLBlast DESTINATION lib)
 install(FILES include/clblast.h DESTINATION include)
 install(FILES include/clblast_c.h DESTINATION include)
 install(FILES include/clblast_half.h DESTINATION include)
+
+# Installs the config for find_package in dependent projects
+install(EXPORT CLBlast DESTINATION lib/cmake/CLBLast FILE CLBlastConfig.cmake)
 
 # ==================================================================================================
 
@@ -194,6 +199,11 @@ endif()
 if(DEFINED ENV{DEFAULT_PLATFORM})
   set(DEVICEPLATFORM ${DEVICEPLATFORM} -platform $ENV{DEFAULT_PLATFORM})
 endif()
+
+# ==================================================================================================
+
+# Includes directories: CLBlast and OpenCL
+include_directories(${clblast_SOURCE_DIR}/include ${clblast_SOURCE_DIR}/src ${OPENCL_INCLUDE_DIRS})
 
 # ==================================================================================================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,11 +202,6 @@ endif()
 
 # ==================================================================================================
 
-# Includes directories: CLBlast and OpenCL
-include_directories(${clblast_SOURCE_DIR}/include ${clblast_SOURCE_DIR}/src ${OPENCL_INCLUDE_DIRS})
-
-# ==================================================================================================
-
 # This section contains all the code related to the examples
 if(SAMPLES)
 
@@ -236,7 +231,6 @@ endif()
 if(TUNERS)
 
   # Includes CLTune
-  include_directories(${CLTUNE_INCLUDE_DIRS})
 
   # Visual Studio requires the sources of non-exported objects/libraries
   set(TUNERS_COMMON )
@@ -248,6 +242,7 @@ if(TUNERS)
   foreach(KERNEL ${KERNELS})
     add_executable(clblast_tuner_${KERNEL} ${TUNERS_COMMON} src/tuning/kernels/${KERNEL}.cpp)
     target_link_libraries(clblast_tuner_${KERNEL} clblast ${CLTUNE_LIBRARIES} ${OPENCL_LIBRARIES})
+    target_include_directories(clblast_tuner_${KERNEL} PUBLIC ${CLTUNE_INCLUDE_DIRS})
     install(TARGETS clblast_tuner_${KERNEL} DESTINATION bin)
   endforeach()
 
@@ -291,9 +286,6 @@ if(CLIENTS OR TESTS)
     endif()
   endif()
 
-  # Sets the include directories
-  include_directories(${clblast_SOURCE_DIR} ${REF_INCLUDES})
-
 endif()
 
 # ==================================================================================================
@@ -309,6 +301,10 @@ if(CLIENTS)
   else()
     # Creates the common performance-tests objects (requires CMake 2.8.8)
     add_library(test_performance_common OBJECT test/performance/client.cpp)
+    # Adds clblast's interface include pathes because we can't link to clblast here
+    target_include_directories(test_performance_common PRIVATE
+                               $<TARGET_PROPERTY:clblast,INTERFACE_INCLUDE_DIRECTORIES>
+                               ${clblast_SOURCE_DIR})
     set(CLIENTS_COMMON ${CLIENTS_COMMON} $<TARGET_OBJECTS:test_performance_common>)
   endif()
 
@@ -331,6 +327,7 @@ if(CLIENTS)
   endforeach()
   foreach(ROUTINE ${ROUTINES})
     target_link_libraries(clblast_client_${ROUTINE} clblast ${REF_LIBRARIES} ${OPENCL_LIBRARIES})
+    target_include_directories(clblast_client_${ROUTINE} PUBLIC ${clblast_SOURCE_DIR} ${REF_INCLUDES})
     install(TARGETS clblast_client_${ROUTINE} DESTINATION bin)
   endforeach()
 
@@ -352,6 +349,9 @@ if(TESTS)
     # Creates the common correctness-tests objects (requires CMake 2.8.8)
     add_library(test_correctness_common OBJECT
                 test/correctness/tester.cpp test/correctness/testblas.cpp)
+    target_include_directories(test_correctness_common PUBLIC
+                               $<TARGET_PROPERTY:clblast,INTERFACE_INCLUDE_DIRECTORIES>
+                               ${clblast_SOURCE_DIR})
     set(TESTS_COMMON ${TESTS_COMMON} $<TARGET_OBJECTS:test_correctness_common>)
   endif()
 
@@ -375,6 +375,7 @@ if(TESTS)
   foreach(ROUTINE ${ROUTINES})
     target_link_libraries(clblast_test_${ROUTINE} clblast ${REF_LIBRARIES} ${OPENCL_LIBRARIES})
     install(TARGETS clblast_test_${ROUTINE} DESTINATION bin)
+    target_include_directories(clblast_test_${ROUTINE} PUBLIC ${clblast_SOURCE_DIR} ${REF_INCLUDES})
     add_test(clblast_test_${ROUTINE} clblast_test_${ROUTINE} ${DEVICEPLATFORM})
   endforeach()
 


### PR DESCRIPTION
I believe in pipelining, so here it is, in case you are OK with bumping the CMake dep to 3.2 (see #85).

This allows me to link to CLBlast in Caffe's CMakeLists.txt in ~15 lines of code (see [intelfx/caffe#clblast](https://github.com/intelfx/caffe/tree/clblast)) without writing any boilerplate, with support for non-standard prefixes and all that (so I'm not NOT just adding `-lclblast` to the compiler command line and calling it a day).