### PR TITLE
test/correctness: read platform and device from environment

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -161,6 +161,8 @@ template <typename T>
 T ConvertArgument(const char* value) {
   return static_cast<T>(std::stoi(value));
 }
+template size_t ConvertArgument(const char* value);
+
 template <> half ConvertArgument(const char* value) {
   return FloatToHalf(static_cast<float>(std::stod(value)));
 }
@@ -178,6 +180,15 @@ template <> double2 ConvertArgument(const char* value) {
   auto val = static_cast<double>(std::stod(value));
   return double2{val, val};
 }
+
+// Variant of "ConvertArgument" with default values
+template <typename T>
+T ConvertArgument(const char* value, T default_value) {
+
+  if (value) { return ConvertArgument<T>(value); }
+  return default_value;
+}
+template size_t ConvertArgument(const char* value, size_t default_value);
 
 // This function matches patterns in the form of "-option value" or "--option value". It returns a
 // default value in case the option is not found in the argument string.

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -187,6 +187,10 @@ std::string ToString(T value);
 template <typename T>
 T ConvertArgument(const char* value);
 
+// Variant of "ConvertArgument" with default values
+template <typename T>
+T ConvertArgument(const char* value, T default_value);
+
 // Basic argument parser, matching patterns in the form of "-option value" and "--option value"
 template <typename T>
 T GetArgument(const int argc, char **argv, std::string &help,

--- a/test/correctness/tester.cpp
+++ b/test/correctness/tester.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <iostream>
 #include <cmath>
+#include <cstdlib>
 
 #include "test/correctness/tester.hpp"
 
@@ -27,8 +28,8 @@ template <typename T, typename U>
 Tester<T,U>::Tester(int argc, char *argv[], const bool silent,
                     const std::string &name, const std::vector<std::string> &options):
     help_("Options given/available:\n"),
-    platform_(Platform(GetArgument(argc, argv, help_, kArgPlatform, size_t{0}))),
-    device_(Device(platform_, GetArgument(argc, argv, help_, kArgDevice, size_t{0}))),
+    platform_(Platform(GetArgument(argc, argv, help_, kArgPlatform, ConvertArgument(std::getenv("CLBLAST_PLATFORM"), size_t{0})))),
+    device_(Device(platform_, GetArgument(argc, argv, help_, kArgDevice, ConvertArgument(std::getenv("CLBLAST_DEVICE"), size_t{0})))),
     context_(Context(device_)),
     queue_(Queue(context_, device_)),
     full_test_(CheckArgument(argc, argv, help_, kArgFullTest)),


### PR DESCRIPTION
Support passing environment variables `CLBLAST_PLATFORM` and `CLBLAST_DEVICE` instead of `-platform` and `-device` arguments to test executables.
    
This is for `ctest`.

(If you remember, earlier I tried to include this commit but it failed unit tests. Now I finally understood the problem.)