### PR TITLE
CMakeLists.txt: use -Wno-ignored-attributes to silence unfixable warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,12 @@ else()
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
       set(FLAGS "${FLAGS} -Wno-attributes -Wno-unused-variable")
     endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0.0)
+      # GCC does not support attributes on template arguments
+      # in particular we hit this with the alignment attributes on cl_XXX types
+      # which are then used to instantiate various templates in CLBlast
+      set(FLAGS "${FLAGS} -Wno-ignored-attributes")
+    endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES Clang)
     set(FLAGS "${FLAGS} -Wextra -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded")
     set(FLAGS "${FLAGS} -Wno-missing-prototypes -Wno-float-equal -Wno-switch-enum -Wno-switch")


### PR DESCRIPTION
The GCC type system does not support attributes (such as `__attribute__((align(N)))` on template arguments. Consequently, each instantiation of a template using a `cl_XXX` type yields a warning:

```
/home/ivan/CK/tools/lib-viennacl-1.7.1-gcc-6.2.0-linux-32/include/viennacl/meta/predicate.hpp:513:39: warning: ignoring attributes on template argument 'cl_double {aka double}' [-Wignored-attributes]
 template<> struct is_cl_type<cl_double>{ enum { value = true }; };
```

Strictly speaking, dropping alignment is wrong. However,

* the only way to fix this for real is to apply required attributes directly to each variable declared inside those templates (which is impractical and actually impossible because the alignment values are an implementation detail);
* the alignments currently specified there are already provided at least by x86_64 and ARMv7 ABIs.

Hence this pull request: let's just silence the warning because it severely clutters the compilation output and it is unlikely to hit the problem in real world and.