### PR TITLE
Add path to ref library header when building tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,7 +356,7 @@ if(TESTS)
                 test/correctness/tester.cpp test/correctness/testblas.cpp)
     target_include_directories(test_correctness_common PUBLIC
                                $<TARGET_PROPERTY:clblast,INTERFACE_INCLUDE_DIRECTORIES>
-                               ${clblast_SOURCE_DIR})
+                               ${clblast_SOURCE_DIR} ${REF_INCLUDES})
     set(TESTS_COMMON ${TESTS_COMMON} $<TARGET_OBJECTS:test_correctness_common>)
   endif()
 


### PR DESCRIPTION
Building the `test_correctness_common` target fails when a reference library header (e.g. `clBLAS.h`) is not in standard paths. This PR adds the header path to the target's include directories.