### PR TITLE
Generate and install pkg-config description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,14 @@ install(FILES include/clblast_half.h DESTINATION include)
 # Installs the config for find_package in dependent projects
 install(EXPORT CLBlast DESTINATION lib/cmake/CLBLast FILE CLBlastConfig.cmake)
 
+# Install pkg-config file on Linux
+if(UNIX)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/clblast.pc.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/clblast.pc" @ONLY IMMEDIATE)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/clblast.pc
+            DESTINATION lib/pkgconfig)
+endif()
+
 # ==================================================================================================
 
 # Sets a default platform ($DEVICEPLATFORM) and device ($CLBLAST_DEVICE) to run tuners and tests on

--- a/src/clblast.pc.in
+++ b/src/clblast.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: CLBlast
+Description: CLBlast is a modern, lightweight, performant and tunable OpenCL BLAS library written in C++11
+Version: @clblast_VERSION_MAJOR@.@clblast_VERSION_MINOR@.@clblast_VERSION_PATCH@
+Libs: -L${libdir} -lclblast
+Cflags: -I${includedir}


### PR DESCRIPTION
[pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) is a more general approach for source configuration than the one included with CMake, allowing non-CMake projects (e.g. those using handwritten Makefiles or Autotools) to find and compile against CLBlast correctly.