### PR TITLE
Refactor cache subsystem

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -20,103 +20,73 @@
 namespace clblast {
 // =================================================================================================
 
-// Stores the compiled binary or IR in the cache
-void StoreBinaryToCache(const std::string &binary, const std::string &device_name,
-                        const Precision &precision, const std::string &routine_name) {
-  #ifdef VERBOSE
-    printf("[DEBUG] Storing binary in cache\n");
-  #endif
-  binary_cache_mutex_.lock();
-  binary_cache_.push_back(BinaryCache{binary, device_name, precision, routine_name});
-  binary_cache_mutex_.unlock();
-}
+template <typename Key, typename Value>
+template <typename U>
+Value Cache<Key, Value>::Get(const U &key, bool *in_cache) const {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
 
-// Stores the compiled program in the cache
-void StoreProgramToCache(const Program &program, const Context &context,
-                         const Precision &precision, const std::string &routine_name) {
-  #ifdef VERBOSE
-    printf("[DEBUG] Storing program in cache\n");
-  #endif
-  program_cache_mutex_.lock();
-  program_cache_.push_back(ProgramCache{program, context(), precision, routine_name});
-  program_cache_mutex_.unlock();
-}
-
-// Queries the cache and retrieves a matching binary. Assumes that the match is available, throws
-// otherwise.
-const std::string& GetBinaryFromCache(const std::string &device_name, const Precision &precision,
-                                      const std::string &routine_name) {
-  #ifdef VERBOSE
-    printf("[DEBUG] Retrieving binary from cache\n");
-  #endif
-  binary_cache_mutex_.lock();
-  for (auto &cached_binary: binary_cache_) {
-    if (cached_binary.MatchInCache(device_name, precision, routine_name)) {
-      binary_cache_mutex_.unlock();
-      return cached_binary.binary;
+#if __cplusplus >= 201402L
+  // generalized std::map::find() of C++14
+  auto it = cache_.find(key);
+#else
+  // O(n) lookup in a vector
+  auto it = std::find_if(cache_.begin(), cache_.end(), [&] (const std::pair<Key, Value> &pair) {
+    return pair.first == key;
+  });
+#endif
+  if (it == cache_.end()) {
+    if (in_cache) {
+      *in_cache = false;
     }
+    return Value();
   }
-  binary_cache_mutex_.unlock();
-  throw LogicError("GetBinaryFromCache: Expected binary in cache, but found none");
+
+  if (in_cache) {
+    *in_cache = true;
+  }
+  return it->second;
 }
 
-// Queries the cache and retrieves a matching program. Assumes that the match is available, throws
-// otherwise.
-const Program& GetProgramFromCache(const Context &context, const Precision &precision,
-                                   const std::string &routine_name) {
-  #ifdef VERBOSE
-    printf("[DEBUG] Retrieving program from cache\n");
-  #endif
-  program_cache_mutex_.lock();
-  for (auto &cached_program: program_cache_) {
-    if (cached_program.MatchInCache(context(), precision, routine_name)) {
-      program_cache_mutex_.unlock();
-      return cached_program.program;
-    }
+template <typename Key, typename Value>
+void Cache<Key, Value>::Store(Key &&key, Value &&value) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+#if __cplusplus >= 201402L
+  // emplace() into a map
+  auto r = cache_.emplace(std::move(key), std::move(value));
+  if (!r.second) {
+    throw LogicError("Cache::Store: object already in cache");
   }
-  program_cache_mutex_.unlock();
-  throw LogicError("GetProgramFromCache: Expected program in cache, but found none");
+#else
+  // emplace_back() into a vector
+  cache_.emplace_back(std::move(key), std::move(value));
+#endif
 }
 
-// Queries the cache to see whether or not the compiled kernel is already there
-bool BinaryIsInCache(const std::string &device_name, const Precision &precision,
-                     const std::string &routine_name) {
-  binary_cache_mutex_.lock();
-  for (auto &cached_binary: binary_cache_) {
-    if (cached_binary.MatchInCache(device_name, precision, routine_name)) {
-      binary_cache_mutex_.unlock();
-      return true;
-    }
-  }
-  binary_cache_mutex_.unlock();
-  return false;
+template <typename Key, typename Value>
+void Cache<Key, Value>::Invalidate() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  cache_.clear();
 }
 
-// Queries the cache to see whether or not the compiled kernel is already there
-bool ProgramIsInCache(const Context &context, const Precision &precision,
-                      const std::string &routine_name) {
-  program_cache_mutex_.lock();
-  for (auto &cached_program: program_cache_) {
-    if (cached_program.MatchInCache(context(), precision, routine_name)) {
-      program_cache_mutex_.unlock();
-      return true;
-    }
-  }
-  program_cache_mutex_.unlock();
-  return false;
+template <typename Key, typename Value>
+Cache<Key, Value> &Cache<Key, Value>::Instance() {
+  return instance_;
 }
+
+template <typename Key, typename Value>
+Cache<Key, Value> Cache<Key, Value>::instance_;
 
 // =================================================================================================
 
-// Clears the cache of stored binaries and programs
-void CacheClearAll() {
-  binary_cache_mutex_.lock();
-  binary_cache_.clear();
-  binary_cache_mutex_.unlock();
-  program_cache_mutex_.lock();
-  program_cache_.clear();
-  program_cache_mutex_.unlock();
-}
+template class Cache<BinaryKey, std::string>;
+template std::string BinaryCache::Get(const BinaryKeyRef &, bool *) const;
+
+// =================================================================================================
+
+template class Cache<ProgramKey, Program>;
+template Program ProgramCache::Get(const ProgramKeyRef &, bool *) const;
 
 // =================================================================================================
 } // namespace clblast

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <mutex>
 
+#include "database/database.hpp"
 #include "cache.hpp"
 
 namespace clblast {
@@ -87,6 +88,11 @@ template std::string BinaryCache::Get(const BinaryKeyRef &, bool *) const;
 
 template class Cache<ProgramKey, Program>;
 template Program ProgramCache::Get(const ProgramKeyRef &, bool *) const;
+
+// =================================================================================================
+
+template class Cache<DatabaseKey, Database>;
+template Database DatabaseCache::Get(const DatabaseKeyRef &, bool *) const;
 
 // =================================================================================================
 } // namespace clblast

--- a/src/cache.hpp
+++ b/src/cache.hpp
@@ -86,6 +86,20 @@ extern template class Cache<ProgramKey, Program>;
 extern template Program ProgramCache::Get(const ProgramKeyRef &, bool *) const;
 
 // =================================================================================================
+
+class Database;
+
+// The key struct for the cache of database maps.
+// Order of fields: precision, device_name, routines (smaller fields first)
+typedef std::tuple<Precision, std::string, std::vector<std::string>> DatabaseKey;
+typedef std::tuple<const Precision &, const std::string &, const std::vector<std::string> &> DatabaseKeyRef;
+
+typedef Cache<DatabaseKey, Database> DatabaseCache;
+
+extern template class Cache<DatabaseKey, Database>;
+extern template Database DatabaseCache::Get(const DatabaseKeyRef &, bool *) const;
+
+// =================================================================================================
 } // namespace clblast
 
 // CLBLAST_CACHE_H_

--- a/src/cache.hpp
+++ b/src/cache.hpp
@@ -15,81 +15,75 @@
 #define CLBLAST_CACHE_H_
 
 #include <string>
-#include <vector>
 #include <mutex>
+#include <map>
 
 #include "utilities/utilities.hpp"
 
 namespace clblast {
 // =================================================================================================
 
-// The cache of compiled OpenCL binaries, along with some meta-data
-struct BinaryCache {
-  std::string binary;
-  std::string device_name;
-  Precision precision;
-  std::string routine_name_;
+// The generic thread-safe cache. We assume that the Key may be a heavyweight struct that is not
+// normally used by the caller, while the Value is either lightweight or ref-counted.
+// Hence, searching by non-Key is supported (if there is a corresponding operator<()), and
+// on Store() the Key instance is moved from the caller (because it will likely be constructed
+// as temporary at the time of Store()).
+template <typename Key, typename Value>
+class Cache {
+public:
+  // Cached object is returned by-value to avoid racing with Invalidate().
+  // Due to lack of std::optional<>, in case of a cache miss we return a default-constructed
+  // Value and set the flag to false.
+  template <typename U>
+  Value Get(const U &key, bool *in_cache) const;
 
-  // Finds out whether the properties match
-  bool MatchInCache(const std::string &ref_device, const Precision &ref_precision,
-                    const std::string &ref_routine) {
-    return (device_name == ref_device &&
-            precision == ref_precision &&
-            routine_name_ == ref_routine);
-  }
-};
+  // We do not return references to just stored object to avoid racing with Invalidate().
+  // Caller is expected to store a temporary.
+  void Store(Key &&key, Value &&value);
+  void Invalidate();
 
-// The actual cache, implemented as a vector of the above data-type, and its mutex
-static std::vector<BinaryCache> binary_cache_;
-static std::mutex binary_cache_mutex_;
+  static Cache<Key, Value> &Instance();
 
-// =================================================================================================
+private:
+#if __cplusplus >= 201402L
+  // The std::less<void> allows to search in cache by an object comparable with Key, without
+  // constructing a temporary Key
+  // (see http://en.cppreference.com/w/cpp/utility/functional/less_void,
+  //      http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2013/n3657.htm,
+  //      http://stackoverflow.com/questions/10536788/avoiding-key-construction-for-stdmapfind)
+  std::map<Key, Value, std::less<void>> cache_;
+#else
+  std::vector<std::pair<Key, Value>> cache_;
+#endif
+  mutable std::mutex cache_mutex_;
 
-// The cache of compiled OpenCL programs, along with some meta-data
-struct ProgramCache {
-  Program program;
-  cl_context context;
-  Precision precision;
-  std::string routine_name_;
-
-  // Finds out whether the properties match
-  bool MatchInCache(const cl_context ref_context, const Precision &ref_precision,
-                    const std::string &ref_routine) {
-    return (context == ref_context &&
-            precision == ref_precision &&
-            routine_name_ == ref_routine);
-  }
-};
-
-// The actual cache, implemented as a vector of the above data-type, and its mutex
-static std::vector<ProgramCache> program_cache_;
-static std::mutex program_cache_mutex_;
+  static Cache<Key, Value> instance_;
+}; // class Cache
 
 // =================================================================================================
 
-// Stores the compiled binary or program in the cache
-void StoreBinaryToCache(const std::string &binary, const std::string &device_name,
-                        const Precision &precision, const std::string &routine_name);
-void StoreProgramToCache(const Program &program, const Context &context,
-                         const Precision &precision, const std::string &routine_name);
+// The key struct for the cache of compiled OpenCL binaries
+// Order of fields: precision, routine_name, device_name (smaller fields first)
+typedef std::tuple<Precision, std::string, std::string> BinaryKey;
+typedef std::tuple<const Precision &, const std::string &, const std::string &> BinaryKeyRef;
 
-// Queries the cache and retrieves a matching binary or program. Assumes that the match is
-// available, throws otherwise.
-const std::string& GetBinaryFromCache(const std::string &device_name, const Precision &precision,
-                                      const std::string &routine_name);
-const Program& GetProgramFromCache(const Context &context, const Precision &precision,
-                                   const std::string &routine_name);
+typedef Cache<BinaryKey, std::string> BinaryCache;
 
-// Queries the cache to see whether or not the compiled kernel is already there
-bool BinaryIsInCache(const std::string &device_name, const Precision &precision,
-                     const std::string &routine_name);
-bool ProgramIsInCache(const Context &context, const Precision &precision,
-                      const std::string &routine_name);
+extern template class Cache<BinaryKey, std::string>;
+extern template std::string BinaryCache::Get(const BinaryKeyRef &, bool *) const;
+
 
 // =================================================================================================
 
-// Clears the cache of stored binaries
-void CacheClearAll();
+// The key struct for the cache of compiled OpenCL programs (context-dependent)
+// Order of fields: context, precision, routine_name (smaller fields first)
+typedef std::tuple<cl_context, Precision, std::string> ProgramKey;
+typedef std::tuple<const cl_context &, const Precision &, const std::string &> ProgramKeyRef;
+
+typedef Cache<ProgramKey, Program> ProgramCache;
+
+extern template class Cache<ProgramKey, Program>;
+extern template Program ProgramCache::Get(const ProgramKeyRef &, bool *) const;
 
 // =================================================================================================
 } // namespace clblast

--- a/src/clblast.cpp
+++ b/src/clblast.cpp
@@ -2165,7 +2165,8 @@ template StatusCode PUBLIC_API Omatcopy<half>(const Layout, const Transpose,
 // Clears the cache of stored binaries
 StatusCode ClearCache() {
   try {
-    CacheClearAll();
+    ProgramCache::Instance().Invalidate();
+    BinaryCache::Instance().Invalidate();
   } catch (...) { return DispatchException(); }
   return StatusCode::kSuccess;
 }

--- a/src/clpp11.hpp
+++ b/src/clpp11.hpp
@@ -361,7 +361,7 @@ enum class BuildStatus { kSuccess, kError, kInvalid };
 // C++11 version of 'cl_program'.
 class Program {
  public:
-  // Note that there is no constructor based on the regular OpenCL data-type because of extra state
+  Program() = default;
 
   // Source-based constructor with memory management
   explicit Program(const Context &context, const std::string &source):

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -65,7 +65,7 @@ const std::unordered_map<std::string, std::string> Database::kVendorNames{
 // This takes an optional overlay database in case of custom tuning or custom kernels.
 Database::Database(const Queue &queue, const std::vector<std::string> &kernels,
                    const Precision precision, const std::vector<const DatabaseEntry*> &overlay):
-  parameters_{} {
+  parameters_(std::make_shared<Parameters>()) {
 
   // Finds information of the current device
   auto device = queue.GetDevice();
@@ -87,7 +87,7 @@ Database::Database(const Queue &queue, const std::vector<std::string> &kernels,
     for (auto &db: { database, overlay}) {
       search_result = Search(kernel, device_type, device_vendor, device_name, precision, db);
       if (search_result) {
-        parameters_.insert(search_result->begin(), search_result->end());
+        parameters_->insert(search_result->begin(), search_result->end());
         break;
       }
     }
@@ -101,7 +101,7 @@ Database::Database(const Queue &queue, const std::vector<std::string> &kernels,
 // Returns a list of OpenCL pre-processor defines in string form
 std::string Database::GetDefines() const {
   std::string defines{};
-  for (auto &parameter: parameters_) {
+  for (auto &parameter: *parameters_) {
     defines += "#define "+parameter.first+" "+ToString(parameter.second)+"\n";
   }
   return defines;

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -63,12 +63,11 @@ const std::unordered_map<std::string, std::string> Database::kVendorNames{
 
 // Constructor, computing device properties and populating the parameter-vector from the database.
 // This takes an optional overlay database in case of custom tuning or custom kernels.
-Database::Database(const Queue &queue, const std::vector<std::string> &kernels,
+Database::Database(const Device &device, const std::vector<std::string> &kernels,
                    const Precision precision, const std::vector<const DatabaseEntry*> &overlay):
   parameters_(std::make_shared<Parameters>()) {
 
   // Finds information of the current device
-  auto device = queue.GetDevice();
   auto device_type = device.Type();
   auto device_vendor = device.Vendor();
   auto device_name = device.Name();

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -72,12 +72,14 @@ class Database {
   // The database consists of separate database entries, stored together in a vector
   static const std::vector<const DatabaseEntry*> database;
 
+  Database() = default;
+
   // The constructor with a user-provided database overlay (potentially an empty vector)
   explicit Database(const Queue &queue, const std::vector<std::string> &routines,
                     const Precision precision, const std::vector<const DatabaseEntry*> &overlay);
 
   // Accessor of values by key
-  size_t operator[](const std::string key) const { return parameters_.find(key)->second; }
+  size_t operator[](const std::string key) const { return parameters_->find(key)->second; }
 
   // Obtain a list of OpenCL pre-processor defines based on the parameters
   std::string GetDefines() const;
@@ -90,7 +92,7 @@ class Database {
                        const std::vector<const DatabaseEntry*> &db) const;
 
   // Found parameters suitable for this device/kernel
-  Parameters parameters_;
+  std::shared_ptr<Parameters> parameters_;
 };
 
 // =================================================================================================

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -75,7 +75,7 @@ class Database {
   Database() = default;
 
   // The constructor with a user-provided database overlay (potentially an empty vector)
-  explicit Database(const Queue &queue, const std::vector<std::string> &routines,
+  explicit Database(const Device &device, const std::vector<std::string> &routines,
                     const Precision precision, const std::vector<const DatabaseEntry*> &overlay);
 
   // Accessor of values by key

--- a/src/routine.cpp
+++ b/src/routine.cpp
@@ -48,7 +48,7 @@ void Routine::InitDatabase(const std::vector<std::string> &routines,
   if (has_db) { return; }
 
   // Builds the parameter database for this device and routine set and stores it in the cache
-  db_ = Database(queue_, routines, precision_, userDatabase);
+  db_ = Database(device_, routines, precision_, userDatabase);
   DatabaseCache::Instance().Store(DatabaseKey{ precision_, device_name_, routines },
                                   Database{ db_ });
 }

--- a/src/routine.hpp
+++ b/src/routine.hpp
@@ -35,10 +35,21 @@ class Routine {
   // Base class constructor. The user database is an optional extra database to override the
   // built-in database.
   // All heavy preparation work is done inside this constructor.
+  // NOTE: the caller must provide the same userDatabase for each combination of device, precision
+  // and routine list, otherwise the caching logic will break.
   explicit Routine(Queue &queue, EventPointer event, const std::string &name,
                    const std::vector<std::string> &routines, const Precision precision,
                    const std::vector<const Database::DatabaseEntry*> &userDatabase,
                    std::initializer_list<const char *> source);
+
+ private:
+
+  // Initializes program_, fetching cached program or building one
+  void InitProgram(std::initializer_list<const char *> source);
+
+  // Initializes db_, fetching cached database or building one
+  void InitDatabase(const std::vector<std::string> &routines,
+                    const std::vector<const Database::DatabaseEntry*> &userDatabase);
 
  protected:
 
@@ -61,7 +72,7 @@ class Routine {
   Program program_;
 
   // Connection to the database for all the device-specific parameters
-  const Database db_;
+  Database db_;
 };
 
 // =================================================================================================

--- a/src/routine.hpp
+++ b/src/routine.hpp
@@ -57,6 +57,9 @@ class Routine {
   // OpenCL device properties
   const std::string device_name_;
 
+  // Compiled program (either retrieved from cache or compiled in slow path)
+  Program program_;
+
   // Connection to the database for all the device-specific parameters
   const Database db_;
 };

--- a/src/routines/level1/xamax.cpp
+++ b/src/routines/level1/xamax.cpp
@@ -43,9 +43,8 @@ void Xamax<T>::DoAmax(const size_t n,
   TestVectorIndex(1, imax_buffer, imax_offset);
 
   // Retrieves the Xamax kernels from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel1 = Kernel(program, "Xamax");
-  auto kernel2 = Kernel(program, "XamaxEpilogue");
+  auto kernel1 = Kernel(program_, "Xamax");
+  auto kernel2 = Kernel(program_, "XamaxEpilogue");
 
   // Creates the buffer for intermediate values
   auto temp_size = 2*db_["WGS2"];

--- a/src/routines/level1/xasum.cpp
+++ b/src/routines/level1/xasum.cpp
@@ -43,9 +43,8 @@ void Xasum<T>::DoAsum(const size_t n,
   TestVectorScalar(1, asum_buffer, asum_offset);
 
   // Retrieves the Xasum kernels from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel1 = Kernel(program, "Xasum");
-  auto kernel2 = Kernel(program, "XasumEpilogue");
+  auto kernel1 = Kernel(program_, "Xasum");
+  auto kernel2 = Kernel(program_, "XasumEpilogue");
 
   // Creates the buffer for intermediate values
   auto temp_size = 2*db_["WGS2"];

--- a/src/routines/level1/xaxpy.cpp
+++ b/src/routines/level1/xaxpy.cpp
@@ -52,8 +52,7 @@ void Xaxpy<T>::DoAxpy(const size_t n, const T alpha,
   auto kernel_name = (use_fast_kernel) ? "XaxpyFast" : "Xaxpy";
 
   // Retrieves the Xaxpy kernel from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the kernel arguments
   if (use_fast_kernel) {

--- a/src/routines/level1/xcopy.cpp
+++ b/src/routines/level1/xcopy.cpp
@@ -52,8 +52,7 @@ void Xcopy<T>::DoCopy(const size_t n,
   auto kernel_name = (use_fast_kernel) ? "XcopyFast" : "Xcopy";
 
   // Retrieves the Xcopy kernel from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the kernel arguments
   if (use_fast_kernel) {

--- a/src/routines/level1/xdot.cpp
+++ b/src/routines/level1/xdot.cpp
@@ -46,9 +46,8 @@ void Xdot<T>::DoDot(const size_t n,
   TestVectorScalar(1, dot_buffer, dot_offset);
 
   // Retrieves the Xdot kernels from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel1 = Kernel(program, "Xdot");
-  auto kernel2 = Kernel(program, "XdotEpilogue");
+  auto kernel1 = Kernel(program_, "Xdot");
+  auto kernel2 = Kernel(program_, "XdotEpilogue");
 
   // Creates the buffer for intermediate values
   auto temp_size = 2*db_["WGS2"];

--- a/src/routines/level1/xnrm2.cpp
+++ b/src/routines/level1/xnrm2.cpp
@@ -43,9 +43,8 @@ void Xnrm2<T>::DoNrm2(const size_t n,
   TestVectorScalar(1, nrm2_buffer, nrm2_offset);
 
   // Retrieves the Xnrm2 kernels from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel1 = Kernel(program, "Xnrm2");
-  auto kernel2 = Kernel(program, "Xnrm2Epilogue");
+  auto kernel1 = Kernel(program_, "Xnrm2");
+  auto kernel2 = Kernel(program_, "Xnrm2Epilogue");
 
   // Creates the buffer for intermediate values
   auto temp_size = 2*db_["WGS2"];

--- a/src/routines/level1/xscal.cpp
+++ b/src/routines/level1/xscal.cpp
@@ -49,8 +49,7 @@ void Xscal<T>::DoScal(const size_t n, const T alpha,
   auto kernel_name = (use_fast_kernel) ? "XscalFast" : "Xscal";
 
   // Retrieves the Xscal kernel from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the kernel arguments
   if (use_fast_kernel) {

--- a/src/routines/level1/xswap.cpp
+++ b/src/routines/level1/xswap.cpp
@@ -52,8 +52,7 @@ void Xswap<T>::DoSwap(const size_t n,
   auto kernel_name = (use_fast_kernel) ? "XswapFast" : "Xswap";
 
   // Retrieves the Xswap kernel from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the kernel arguments
   if (use_fast_kernel) {

--- a/src/routines/level2/xgemv.cpp
+++ b/src/routines/level2/xgemv.cpp
@@ -122,8 +122,7 @@ void Xgemv<T>::MatVec(const Layout layout, const Transpose a_transpose,
   }
 
   // Retrieves the Xgemv kernel from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the kernel arguments
   kernel.SetArgument(0, static_cast<int>(m_real));

--- a/src/routines/level2/xger.cpp
+++ b/src/routines/level2/xger.cpp
@@ -53,8 +53,7 @@ void Xger<T>::DoGer(const Layout layout,
   TestVectorY(n, y_buffer, y_offset, y_inc);
 
   // Retrieves the kernel from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, "Xger");
+  auto kernel = Kernel(program_, "Xger");
 
   // Sets the kernel arguments
   kernel.SetArgument(0, static_cast<int>(a_one));

--- a/src/routines/level2/xher.cpp
+++ b/src/routines/level2/xher.cpp
@@ -67,8 +67,7 @@ void Xher<T,U>::DoHer(const Layout layout, const Triangle triangle,
   const auto matching_alpha = GetAlpha(alpha);
 
   // Retrieves the kernel from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, "Xher");
+  auto kernel = Kernel(program_, "Xher");
 
   // Sets the kernel arguments
   kernel.SetArgument(0, static_cast<int>(n));

--- a/src/routines/level2/xher2.cpp
+++ b/src/routines/level2/xher2.cpp
@@ -54,8 +54,7 @@ void Xher2<T>::DoHer2(const Layout layout, const Triangle triangle,
   TestVectorY(n, y_buffer, y_offset, y_inc);
 
   // Retrieves the kernel from the compiled binary
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, "Xher2");
+  auto kernel = Kernel(program_, "Xher2");
 
   // Sets the kernel arguments
   kernel.SetArgument(0, static_cast<int>(n));

--- a/src/routines/level3/xhemm.cpp
+++ b/src/routines/level3/xhemm.cpp
@@ -58,8 +58,7 @@ void Xhemm<T>::DoHemm(const Layout layout, const Side side, const Triangle trian
 
   // Creates a general matrix from the hermitian matrix to be able to run the regular Xgemm
   // routine afterwards
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the arguments for the hermitian-to-squared kernel
   kernel.SetArgument(0, static_cast<int>(k));

--- a/src/routines/level3/xhemm.hpp
+++ b/src/routines/level3/xhemm.hpp
@@ -30,6 +30,7 @@ class Xhemm: public Xgemm<T> {
   using Xgemm<T>::queue_;
   using Xgemm<T>::context_;
   using Xgemm<T>::device_;
+  using Xgemm<T>::program_;
   using Xgemm<T>::db_;
   using Xgemm<T>::DoGemm;
 

--- a/src/routines/level3/xsymm.cpp
+++ b/src/routines/level3/xsymm.cpp
@@ -30,12 +30,12 @@ Xsymm<T>::Xsymm(Queue &queue, EventPointer event, const std::string &name):
 // The main routine
 template <typename T>
 void Xsymm<T>::DoSymm(const Layout layout, const Side side, const Triangle triangle,
-                            const size_t m, const size_t n,
-                            const T alpha,
-                            const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
-                            const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
-                            const T beta,
-                            const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld) {
+                      const size_t m, const size_t n,
+                      const T alpha,
+                      const Buffer<T> &a_buffer, const size_t a_offset, const size_t a_ld,
+                      const Buffer<T> &b_buffer, const size_t b_offset, const size_t b_ld,
+                      const T beta,
+                      const Buffer<T> &c_buffer, const size_t c_offset, const size_t c_ld) {
 
   // Makes sure all dimensions are larger than zero
   if ((m == 0) || (n == 0) ) { throw BLASError(StatusCode::kInvalidDimension); }
@@ -58,8 +58,7 @@ void Xsymm<T>::DoSymm(const Layout layout, const Side side, const Triangle trian
 
   // Creates a general matrix from the symmetric matrix to be able to run the regular Xgemm
   // routine afterwards
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the arguments for the symmetric-to-squared kernel
   kernel.SetArgument(0, static_cast<int>(k));

--- a/src/routines/level3/xsymm.hpp
+++ b/src/routines/level3/xsymm.hpp
@@ -32,6 +32,7 @@ class Xsymm: public Xgemm<T> {
   using Xgemm<T>::queue_;
   using Xgemm<T>::context_;
   using Xgemm<T>::device_;
+  using Xgemm<T>::program_;
   using Xgemm<T>::db_;
   using Xgemm<T>::DoGemm;
 

--- a/src/routines/level3/xsyr2k.cpp
+++ b/src/routines/level3/xsyr2k.cpp
@@ -77,9 +77,6 @@ void Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, const Tran
   // Decides which kernel to run: the upper-triangular or lower-triangular version
   auto kernel_name = (triangle == Triangle::kUpper) ? "XgemmUpper" : "XgemmLower";
 
-  // Loads the program from the database
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-
   // Determines whether or not temporary matrices are needed
   auto a_no_temp = ab_one == n_ceiled && ab_two == k_ceiled && a_ld == n_ceiled && a_offset == 0 &&
                    ab_rotated == false;
@@ -103,7 +100,7 @@ void Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, const Tran
     PadCopyTransposeMatrix(queue_, device_, db_, eventProcessA.pointer(), emptyEventList,
                            ab_one, ab_two, a_ld, a_offset, a_buffer,
                            n_ceiled, k_ceiled, n_ceiled, 0, a_temp,
-                           ConstantOne<T>(), program,
+                           ConstantOne<T>(), program_,
                            true, ab_rotated, false);
     eventWaitList.push_back(eventProcessA);
   }
@@ -112,7 +109,7 @@ void Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, const Tran
     PadCopyTransposeMatrix(queue_, device_, db_, eventProcessB.pointer(), emptyEventList,
                            ab_one, ab_two, b_ld, b_offset, b_buffer,
                            n_ceiled, k_ceiled, n_ceiled, 0, b_temp,
-                           ConstantOne<T>(), program,
+                           ConstantOne<T>(), program_,
                            true, ab_rotated, false);
     eventWaitList.push_back(eventProcessB);
   }
@@ -123,12 +120,12 @@ void Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, const Tran
   PadCopyTransposeMatrix(queue_, device_, db_, eventProcessC.pointer(), emptyEventList,
                          n, n, c_ld, c_offset, c_buffer,
                          n_ceiled, n_ceiled, n_ceiled, 0, c_temp,
-                         ConstantOne<T>(), program,
+                         ConstantOne<T>(), program_,
                          true, c_rotated, false);
   eventWaitList.push_back(eventProcessC);
 
   // Retrieves the XgemmUpper or XgemmLower kernel from the compiled binary
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the kernel arguments
   kernel.SetArgument(0, static_cast<int>(n_ceiled));
@@ -168,7 +165,7 @@ void Xsyr2k<T>::DoSyr2k(const Layout layout, const Triangle triangle, const Tran
   PadCopyTransposeMatrix(queue_, device_, db_, event_, eventWaitList,
                          n_ceiled, n_ceiled, n_ceiled, 0, c_temp,
                          n, n, c_ld, c_offset, c_buffer,
-                         ConstantOne<T>(), program,
+                         ConstantOne<T>(), program_,
                          false, c_rotated, false, upper, lower, false);
 }
 

--- a/src/routines/level3/xsyrk.cpp
+++ b/src/routines/level3/xsyrk.cpp
@@ -74,9 +74,6 @@ void Xsyrk<T>::DoSyrk(const Layout layout, const Triangle triangle, const Transp
   // Decides which kernel to run: the upper-triangular or lower-triangular version
   auto kernel_name = (triangle == Triangle::kUpper) ? "XgemmUpper" : "XgemmLower";
 
-  // Loads the program from the database
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-
   // Determines whether or not temporary matrices are needed
   auto a_no_temp = a_one == n_ceiled && a_two == k_ceiled && a_ld == n_ceiled && a_offset == 0 &&
                    a_rotated == false;
@@ -97,7 +94,7 @@ void Xsyrk<T>::DoSyrk(const Layout layout, const Triangle triangle, const Transp
     PadCopyTransposeMatrix(queue_, device_, db_, eventProcessA.pointer(), emptyEventList,
                            a_one, a_two, a_ld, a_offset, a_buffer,
                            n_ceiled, k_ceiled, n_ceiled, 0, a_temp,
-                           ConstantOne<T>(), program,
+                           ConstantOne<T>(), program_,
                            true, a_rotated, false);
     eventWaitList.push_back(eventProcessA);
   }
@@ -108,12 +105,12 @@ void Xsyrk<T>::DoSyrk(const Layout layout, const Triangle triangle, const Transp
   PadCopyTransposeMatrix(queue_, device_, db_, eventProcessC.pointer(), emptyEventList,
                          n, n, c_ld, c_offset, c_buffer,
                          n_ceiled, n_ceiled, n_ceiled, 0, c_temp,
-                         ConstantOne<T>(), program,
+                         ConstantOne<T>(), program_,
                          true, c_rotated, false);
   eventWaitList.push_back(eventProcessC);
 
   // Retrieves the XgemmUpper or XgemmLower kernel from the compiled binary
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the kernel arguments
   kernel.SetArgument(0, static_cast<int>(n_ceiled));
@@ -142,7 +139,7 @@ void Xsyrk<T>::DoSyrk(const Layout layout, const Triangle triangle, const Transp
   PadCopyTransposeMatrix(queue_, device_, db_, event_, eventWaitList,
                          n_ceiled, n_ceiled, n_ceiled, 0, c_temp,
                          n, n, c_ld, c_offset, c_buffer,
-                         ConstantOne<T>(), program,
+                         ConstantOne<T>(), program_,
                          false, c_rotated, false, upper, lower, false);
 }
 

--- a/src/routines/level3/xtrmm.cpp
+++ b/src/routines/level3/xtrmm.cpp
@@ -70,8 +70,7 @@ void Xtrmm<T>::DoTrmm(const Layout layout, const Side side, const Triangle trian
 
   // Creates a general matrix from the triangular matrix to be able to run the regular Xgemm
   // routine afterwards
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-  auto kernel = Kernel(program, kernel_name);
+  auto kernel = Kernel(program_, kernel_name);
 
   // Sets the arguments for the triangular-to-squared kernel
   kernel.SetArgument(0, static_cast<int>(k));

--- a/src/routines/level3/xtrmm.hpp
+++ b/src/routines/level3/xtrmm.hpp
@@ -31,6 +31,7 @@ class Xtrmm: public Xgemm<T> {
   using Xgemm<T>::queue_;
   using Xgemm<T>::context_;
   using Xgemm<T>::device_;
+  using Xgemm<T>::program_;
   using Xgemm<T>::db_;
   using Xgemm<T>::DoGemm;
 

--- a/src/routines/levelx/xomatcopy.cpp
+++ b/src/routines/levelx/xomatcopy.cpp
@@ -65,14 +65,11 @@ void Xomatcopy<T>::DoOmatcopy(const Layout layout, const Transpose a_transpose,
   TestMatrixA(a_one, a_two, a_buffer, a_offset, a_ld);
   TestMatrixB(b_one, b_two, b_buffer, b_offset, b_ld);
 
-  // Loads the program from the database
-  const auto program = GetProgramFromCache(context_, PrecisionValue<T>(), routine_name_);
-
   auto emptyEventList = std::vector<Event>();
   PadCopyTransposeMatrix(queue_, device_, db_, event_, emptyEventList,
                          a_one, a_two, a_ld, a_offset, a_buffer,
                          b_one, b_two, b_ld, b_offset, b_buffer,
-                         alpha, program, false, transpose, conjugate);
+                         alpha, program_, false, transpose, conjugate);
 }
 
 // =================================================================================================


### PR DESCRIPTION
In this PR I rewrite the cache subsystem almost-from-scratch, making it useful for caching arbitrary objects in different cache instances and using `std::map` internally.

The code gets much cleaner, but there is a downside: **it needs C++14**, in particular [N3465](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3465.pdf) and [N3657](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3657.htm) to allow searching by a tuple of references. If the concern is VS compatibility, then this feature is supported since VS2015 (MSVC 14.0).

In worst case I can change the code to use manual O(n) heterogeneous lookup in a vector, which won't need C++14.

Note that this is on top of PR #131.