### PR TITLE
CBLAS reference code is now separated from device-host copies

### DIFF
--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -353,6 +353,54 @@ void PopulateVector(std::vector<half> &vector, std::mt19937 &mt, std::uniform_re
 
 // =================================================================================================
 
+template <typename T, typename U>
+void DeviceToHost(const Arguments<U> &args, Buffers<T> &buffers, BuffersHost<T> &buffers_host,
+                  Queue &queue, const std::vector<std::string> &names) {
+  for (auto &name: names) {
+    if (name == kBufVecX) {buffers_host.x_vec = std::vector<T>(args.x_size, static_cast<T>(0)); buffers.x_vec.Read(queue, args.x_size, buffers_host.x_vec); }
+    else if (name == kBufVecY) { buffers_host.y_vec = std::vector<T>(args.y_size, static_cast<T>(0)); buffers.y_vec.Read(queue, args.y_size, buffers_host.y_vec); }
+    else if (name == kBufMatA) { buffers_host.a_mat = std::vector<T>(args.a_size, static_cast<T>(0)); buffers.a_mat.Read(queue, args.a_size, buffers_host.a_mat); }
+    else if (name == kBufMatB) { buffers_host.b_mat = std::vector<T>(args.b_size, static_cast<T>(0)); buffers.b_mat.Read(queue, args.b_size, buffers_host.b_mat); }
+    else if (name == kBufMatC) { buffers_host.c_mat = std::vector<T>(args.c_size, static_cast<T>(0)); buffers.c_mat.Read(queue, args.c_size, buffers_host.c_mat); }
+    else if (name == kBufMatAP) { buffers_host.ap_mat = std::vector<T>(args.ap_size, static_cast<T>(0)); buffers.ap_mat.Read(queue, args.ap_size, buffers_host.ap_mat); }
+    else if (name == kBufScalar) { buffers_host.scalar = std::vector<T>(args.scalar_size, static_cast<T>(0)); buffers.scalar.Read(queue, args.scalar_size, buffers_host.scalar); }
+    else { throw std::runtime_error("Invalid buffer name"); }
+  }
+}
+
+template <typename T, typename U>
+void HostToDevice(const Arguments<U> &args, Buffers<T> &buffers, BuffersHost<T> &buffers_host,
+                  Queue &queue, const std::vector<std::string> &names) {
+  for (auto &name: names) {
+    if (name == kBufVecX) { buffers.x_vec.Write(queue, args.x_size, buffers_host.x_vec); }
+    else if (name == kBufVecY) { buffers.y_vec.Write(queue, args.y_size, buffers_host.y_vec); }
+    else if (name == kBufMatA) { buffers.a_mat.Write(queue, args.a_size, buffers_host.a_mat); }
+    else if (name == kBufMatB) { buffers.b_mat.Write(queue, args.b_size, buffers_host.b_mat); }
+    else if (name == kBufMatC) { buffers.c_mat.Write(queue, args.c_size, buffers_host.c_mat); }
+    else if (name == kBufMatAP) { buffers.ap_mat.Write(queue, args.ap_size, buffers_host.ap_mat); }
+    else if (name == kBufScalar) { buffers.scalar.Write(queue, args.scalar_size, buffers_host.scalar); }
+    else { throw std::runtime_error("Invalid buffer name"); }
+  }
+}
+
+// Compiles the above functions
+template void DeviceToHost(const Arguments<half>&, Buffers<half>&, BuffersHost<half>&, Queue&, const std::vector<std::string>&);
+template void DeviceToHost(const Arguments<float>&, Buffers<float>&, BuffersHost<float>&, Queue&, const std::vector<std::string>&);
+template void DeviceToHost(const Arguments<double>&, Buffers<double>&, BuffersHost<double>&, Queue&, const std::vector<std::string>&);
+template void DeviceToHost(const Arguments<float>&, Buffers<float2>&, BuffersHost<float2>&, Queue&, const std::vector<std::string>&);
+template void DeviceToHost(const Arguments<double>&, Buffers<double2>&, BuffersHost<double2>&, Queue&, const std::vector<std::string>&);
+template void DeviceToHost(const Arguments<float2>&, Buffers<float2>&, BuffersHost<float2>&, Queue&, const std::vector<std::string>&);
+template void DeviceToHost(const Arguments<double2>&, Buffers<double2>&, BuffersHost<double2>&, Queue&, const std::vector<std::string>&);
+template void HostToDevice(const Arguments<half>&, Buffers<half>&, BuffersHost<half>&, Queue&, const std::vector<std::string>&);
+template void HostToDevice(const Arguments<float>&, Buffers<float>&, BuffersHost<float>&, Queue&, const std::vector<std::string>&);
+template void HostToDevice(const Arguments<double>&, Buffers<double>&, BuffersHost<double>&, Queue&, const std::vector<std::string>&);
+template void HostToDevice(const Arguments<float>&, Buffers<float2>&, BuffersHost<float2>&, Queue&, const std::vector<std::string>&);
+template void HostToDevice(const Arguments<double>&, Buffers<double2>&, BuffersHost<double2>&, Queue&, const std::vector<std::string>&);
+template void HostToDevice(const Arguments<float2>&, Buffers<float2>&, BuffersHost<float2>&, Queue&, const std::vector<std::string>&);
+template void HostToDevice(const Arguments<double2>&, Buffers<double2>&, BuffersHost<double2>&, Queue&, const std::vector<std::string>&);
+
+// =================================================================================================
+
 // Conversion between half and single-precision
 std::vector<float> HalfToFloatBuffer(const std::vector<half>& source) {
   auto result = std::vector<float>(source.size());

--- a/src/utilities/utilities.hpp
+++ b/src/utilities/utilities.hpp
@@ -98,6 +98,15 @@ constexpr auto kArgHelp = "h";
 constexpr auto kArgQuiet = "q";
 constexpr auto kArgNoAbbreviations = "no_abbrv";
 
+// The buffer names
+constexpr auto kBufVecX = "X";
+constexpr auto kBufVecY = "Y";
+constexpr auto kBufMatA = "A";
+constexpr auto kBufMatB = "B";
+constexpr auto kBufMatC = "C";
+constexpr auto kBufMatAP = "AP";
+constexpr auto kBufScalar = "Scalar";
+
 // =================================================================================================
 
 // Converts a regular or complex type to it's base type (e.g. float2 to float)
@@ -202,6 +211,16 @@ struct Buffers {
   Buffer<T> ap_mat;
   Buffer<T> scalar;
 };
+template <typename T>
+struct BuffersHost {
+  std::vector<T> x_vec;
+  std::vector<T> y_vec;
+  std::vector<T> a_mat;
+  std::vector<T> b_mat;
+  std::vector<T> c_mat;
+  std::vector<T> ap_mat;
+  std::vector<T> scalar;
+};
 
 // =================================================================================================
 
@@ -247,6 +266,18 @@ constexpr auto kTestDataUpperLimit = 2.0;
 // Populates a vector with random data
 template <typename T>
 void PopulateVector(std::vector<T> &vector, std::mt19937 &mt, std::uniform_real_distribution<double> &dist);
+
+// =================================================================================================
+
+// Copies buffers from the OpenCL device to the host
+template <typename T, typename U>
+void DeviceToHost(const Arguments<U> &args, Buffers<T> &buffers, BuffersHost<T> &buffers_host,
+                  Queue &queue, const std::vector<std::string> &names);
+
+// Copies buffers from the host to the OpenCL device
+template <typename T, typename U>
+void HostToDevice(const Arguments<U> &args, Buffers<T> &buffers, BuffersHost<T> &buffers_host,
+                  Queue &queue, const std::vector<std::string> &names);
 
 // =================================================================================================
 

--- a/test/correctness/testblas.cpp
+++ b/test/correctness/testblas.cpp
@@ -67,15 +67,17 @@ TestBlas<T,U>::TestBlas(const std::vector<std::string> &arguments, const bool si
     kBetaValues(GetExampleScalars<U>(full_test_)),
     prepare_data_(prepare_data),
     run_routine_(run_routine),
+    run_reference1_(run_reference1),
+    run_reference2_(run_reference2),
     get_result_(get_result),
     get_index_(get_index),
     get_id1_(get_id1),
     get_id2_(get_id2) {
 
-  // Sets the reference to test against
-  if (compare_clblas_) { run_reference_ = run_reference1; }
-  else if (compare_cblas_) { run_reference_ = run_reference2; }
-  else { throw std::runtime_error("Invalid configuration: no reference to test against"); }
+  // Sanity check
+  if (!compare_clblas_ && !compare_cblas_) {
+    throw std::runtime_error("Invalid configuration: no reference to test against");
+  }
 
   // Computes the maximum sizes. This allows for a single set of input/output buffers.
   const auto max_vec = *std::max_element(kVectorDims.begin(), kVectorDims.end());
@@ -184,7 +186,9 @@ void TestBlas<T,U>::TestRegular(std::vector<Arguments<U>> &test_vector, const st
       else if (compare_cblas_) { fprintf(stdout, " [CPU BLAS]"); }
       std::cout << std::flush;
     }
-    const auto status1 = run_reference_(args, buffers1, queue_);
+    auto status1 = StatusCode::kSuccess;
+    if (compare_clblas_) { status1 = run_reference1_(args, buffers1, queue_); }
+    else if (compare_cblas_) { status1 = run_reference2_(args, buffers1, queue_); }
 
     // Tests for equality of the two status codes
     if (verbose_) { fprintf(stdout, " -> "); std::cout << std::flush; }
@@ -305,7 +309,9 @@ void TestBlas<T,U>::TestInvalid(std::vector<Arguments<U>> &test_vector, const st
       else if (compare_cblas_) { fprintf(stdout, " [CPU BLAS]"); }
       std::cout << std::flush;
     }
-    const auto status1 = run_reference_(args, buffers1, queue_);
+    auto status1 = StatusCode::kSuccess;
+    if (compare_clblas_) { status1 = run_reference1_(args, buffers1, queue_); }
+    else if (compare_cblas_) { status1 = run_reference2_(args, buffers1, queue_); }
 
     // Tests for equality of the two status codes
     if (verbose_) { fprintf(stdout, " -> "); std::cout << std::flush; }

--- a/test/routines/level1/xamax.hpp
+++ b/test/routines/level1/xamax.hpp
@@ -43,6 +43,8 @@ class TestXamax {
             kArgXInc,
             kArgXOffset, kArgImaxOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufScalar}; }
+  static std::vector<std::string> BuffersOut() { return {kBufScalar}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -101,15 +103,10 @@ class TestXamax {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> scalar_cpu(args.scalar_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.scalar.Read(queue, args.scalar_size, scalar_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXamax(args.n,
-                 scalar_cpu, args.imax_offset,
-                 x_vec_cpu, args.x_offset, args.x_inc);
-      buffers.scalar.Write(queue, args.scalar_size, scalar_cpu);
+                 buffers_host.scalar, args.imax_offset,
+                 buffers_host.x_vec, args.x_offset, args.x_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xasum.hpp
+++ b/test/routines/level1/xasum.hpp
@@ -43,6 +43,8 @@ class TestXasum {
             kArgXInc,
             kArgXOffset, kArgAsumOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufScalar}; }
+  static std::vector<std::string> BuffersOut() { return {kBufScalar}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -101,15 +103,10 @@ class TestXasum {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> scalar_cpu(args.scalar_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.scalar.Read(queue, args.scalar_size, scalar_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXasum(args.n,
-                 scalar_cpu, args.asum_offset,
-                 x_vec_cpu, args.x_offset, args.x_inc);
-      buffers.scalar.Write(queue, args.scalar_size, scalar_cpu);
+                 buffers_host.scalar, args.asum_offset,
+                 buffers_host.x_vec, args.x_offset, args.x_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xaxpy.hpp
+++ b/test/routines/level1/xaxpy.hpp
@@ -44,6 +44,8 @@ class TestXaxpy {
             kArgXOffset, kArgYOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -102,15 +104,10 @@ class TestXaxpy {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXaxpy(args.n, args.alpha,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xcopy.hpp
+++ b/test/routines/level1/xcopy.hpp
@@ -43,6 +43,8 @@ class TestXcopy {
             kArgXInc, kArgYInc,
             kArgXOffset, kArgYOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -101,15 +103,10 @@ class TestXcopy {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXcopy(args.n,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xdot.hpp
+++ b/test/routines/level1/xdot.hpp
@@ -43,6 +43,8 @@ class TestXdot {
             kArgXInc, kArgYInc,
             kArgXOffset, kArgYOffset, kArgDotOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufVecY, kBufScalar}; }
+  static std::vector<std::string> BuffersOut() { return {kBufScalar}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -107,18 +109,11 @@ class TestXdot {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> scalar_cpu(args.scalar_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.scalar.Read(queue, args.scalar_size, scalar_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXdot(args.n,
-                scalar_cpu, args.dot_offset,
-                x_vec_cpu, args.x_offset, args.x_inc,
-                y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.scalar.Write(queue, args.scalar_size, scalar_cpu);
+                buffers_host.scalar, args.dot_offset,
+                buffers_host.x_vec, args.x_offset, args.x_inc,
+                buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xdotc.hpp
+++ b/test/routines/level1/xdotc.hpp
@@ -43,6 +43,8 @@ class TestXdotc {
             kArgXInc, kArgYInc,
             kArgXOffset, kArgYOffset, kArgDotOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufVecY, kBufScalar}; }
+  static std::vector<std::string> BuffersOut() { return {kBufScalar}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -107,18 +109,11 @@ class TestXdotc {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> scalar_cpu(args.scalar_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.scalar.Read(queue, args.scalar_size, scalar_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXdotc(args.n,
-                 scalar_cpu, args.dot_offset,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.scalar.Write(queue, args.scalar_size, scalar_cpu);
+                 buffers_host.scalar, args.dot_offset,
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xdotu.hpp
+++ b/test/routines/level1/xdotu.hpp
@@ -43,6 +43,8 @@ class TestXdotu {
             kArgXInc, kArgYInc,
             kArgXOffset, kArgYOffset, kArgDotOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufVecY, kBufScalar}; }
+  static std::vector<std::string> BuffersOut() { return {kBufScalar}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -107,18 +109,11 @@ class TestXdotu {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> scalar_cpu(args.scalar_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.scalar.Read(queue, args.scalar_size, scalar_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXdotu(args.n,
-                 scalar_cpu, args.dot_offset,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.scalar.Write(queue, args.scalar_size, scalar_cpu);
+                 buffers_host.scalar, args.dot_offset,
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xnrm2.hpp
+++ b/test/routines/level1/xnrm2.hpp
@@ -43,6 +43,8 @@ class TestXnrm2 {
             kArgXInc,
             kArgXOffset, kArgNrm2Offset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufScalar}; }
+  static std::vector<std::string> BuffersOut() { return {kBufScalar}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -101,15 +103,10 @@ class TestXnrm2 {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> scalar_cpu(args.scalar_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.scalar.Read(queue, args.scalar_size, scalar_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXnrm2(args.n,
-                 scalar_cpu, args.nrm2_offset,
-                 x_vec_cpu, args.x_offset, args.x_inc);
-      buffers.scalar.Write(queue, args.scalar_size, scalar_cpu);
+                 buffers_host.scalar, args.nrm2_offset,
+                 buffers_host.x_vec, args.x_offset, args.x_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xscal.hpp
+++ b/test/routines/level1/xscal.hpp
@@ -44,6 +44,8 @@ class TestXscal {
             kArgXOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecX}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -96,12 +98,9 @@ class TestXscal {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXscal(args.n, args.alpha,
-                 x_vec_cpu, args.x_offset, args.x_inc);
-      buffers.x_vec.Write(queue, args.x_size, x_vec_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level1/xswap.hpp
+++ b/test/routines/level1/xswap.hpp
@@ -43,6 +43,8 @@ class TestXswap {
             kArgXInc, kArgYInc,
             kArgXOffset, kArgYOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecX, kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -101,16 +103,10 @@ class TestXswap {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXswap(args.n,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.x_vec.Write(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xgbmv.hpp
+++ b/test/routines/level2/xgbmv.hpp
@@ -45,6 +45,8 @@ class TestXgbmv {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -118,20 +120,13 @@ class TestXgbmv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXgbmv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.a_transpose),
                  args.m, args.n, args.kl, args.ku, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc, args.beta,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc, args.beta,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xgemv.hpp
+++ b/test/routines/level2/xgemv.hpp
@@ -45,6 +45,8 @@ class TestXgemv {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -118,20 +120,13 @@ class TestXgemv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXgemv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.a_transpose),
                  args.m, args.n, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc, args.beta,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc, args.beta,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xger.hpp
+++ b/test/routines/level2/xger.hpp
@@ -45,6 +45,8 @@ class TestXger {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatA}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -113,19 +115,12 @@ class TestXger {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXger(convertToCBLAS(args.layout),
                 args.m, args.n, args.alpha,
-                x_vec_cpu, args.x_offset, args.x_inc,
-                y_vec_cpu, args.y_offset, args.y_inc,
-                a_mat_cpu, args.a_offset, args.a_ld);
-      buffers.a_mat.Write(queue, args.a_size, a_mat_cpu);
+                buffers_host.x_vec, args.x_offset, args.x_inc,
+                buffers_host.y_vec, args.y_offset, args.y_inc,
+                buffers_host.a_mat, args.a_offset, args.a_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xgerc.hpp
+++ b/test/routines/level2/xgerc.hpp
@@ -45,6 +45,8 @@ class TestXgerc {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatA}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -113,19 +115,12 @@ class TestXgerc {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXgerc(convertToCBLAS(args.layout),
                  args.m, args.n, args.alpha,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc,
-                 a_mat_cpu, args.a_offset, args.a_ld);
-      buffers.a_mat.Write(queue, args.a_size, a_mat_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc,
+                 buffers_host.a_mat, args.a_offset, args.a_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xgeru.hpp
+++ b/test/routines/level2/xgeru.hpp
@@ -45,6 +45,8 @@ class TestXgeru {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatA}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -113,19 +115,12 @@ class TestXgeru {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXgeru(convertToCBLAS(args.layout),
                  args.m, args.n, args.alpha,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc,
-                 a_mat_cpu, args.a_offset, args.a_ld);
-      buffers.a_mat.Write(queue, args.a_size, a_mat_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc,
+                 buffers_host.a_mat, args.a_offset, args.a_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xhbmv.hpp
+++ b/test/routines/level2/xhbmv.hpp
@@ -45,6 +45,8 @@ class TestXhbmv {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXhbmv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXhbmv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.kl, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc, args.beta,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc, args.beta,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xhemv.hpp
+++ b/test/routines/level2/xhemv.hpp
@@ -45,6 +45,8 @@ class TestXhemv {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXhemv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXhemv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc, args.beta,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc, args.beta,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xher.hpp
+++ b/test/routines/level2/xher.hpp
@@ -45,6 +45,8 @@ class TestXher {
             kArgAOffset, kArgXOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatA}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<U> &args) {
@@ -106,17 +108,12 @@ class TestXher {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<U> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<U> &args, BuffersHost<T> &buffers_host, Queue&) {
       cblasXher(convertToCBLAS(args.layout),
                 convertToCBLAS(args.triangle),
                 args.n, args.alpha,
-                x_vec_cpu, args.x_offset, args.x_inc,
-                a_mat_cpu, args.a_offset, args.a_ld);
-      buffers.a_mat.Write(queue, args.a_size, a_mat_cpu);
+                buffers_host.x_vec, args.x_offset, args.x_inc,
+                buffers_host.a_mat, args.a_offset, args.a_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xher2.hpp
+++ b/test/routines/level2/xher2.hpp
@@ -45,6 +45,8 @@ class TestXher2 {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatA}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXher2 {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXher2(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.alpha,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc,
-                 a_mat_cpu, args.a_offset, args.a_ld);
-      buffers.a_mat.Write(queue, args.a_size, a_mat_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc,
+                 buffers_host.a_mat, args.a_offset, args.a_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xhpmv.hpp
+++ b/test/routines/level2/xhpmv.hpp
@@ -45,6 +45,8 @@ class TestXhpmv {
             kArgAPOffset, kArgXOffset, kArgYOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatAP, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXhpmv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> ap_mat_cpu(args.ap_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.ap_mat.Read(queue, args.ap_size, ap_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXhpmv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.alpha,
-                 ap_mat_cpu, args.ap_offset,
-                 x_vec_cpu, args.x_offset, args.x_inc, args.beta,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.ap_mat, args.ap_offset,
+                 buffers_host.x_vec, args.x_offset, args.x_inc, args.beta,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xhpr.hpp
+++ b/test/routines/level2/xhpr.hpp
@@ -45,6 +45,8 @@ class TestXhpr {
             kArgAPOffset, kArgXOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatAP, kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatAP}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<U> &args) {
@@ -106,17 +108,12 @@ class TestXhpr {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<U> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> ap_mat_cpu(args.ap_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.ap_mat.Read(queue, args.ap_size, ap_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<U> &args, BuffersHost<T> &buffers_host, Queue&) {
       cblasXhpr(convertToCBLAS(args.layout),
                 convertToCBLAS(args.triangle),
                 args.n, args.alpha,
-                x_vec_cpu, args.x_offset, args.x_inc,
-                ap_mat_cpu, args.ap_offset);
-      buffers.ap_mat.Write(queue, args.ap_size, ap_mat_cpu);
+                buffers_host.x_vec, args.x_offset, args.x_inc,
+                buffers_host.ap_mat, args.ap_offset);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xhpr2.hpp
+++ b/test/routines/level2/xhpr2.hpp
@@ -45,6 +45,8 @@ class TestXhpr2 {
             kArgAPOffset, kArgXOffset, kArgYOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatAP, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatAP}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXhpr2 {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> ap_mat_cpu(args.ap_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.ap_mat.Read(queue, args.ap_size, ap_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXhpr2(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.alpha,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc,
-                 ap_mat_cpu, args.ap_offset);
-      buffers.ap_mat.Write(queue, args.ap_size, ap_mat_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc,
+                 buffers_host.ap_mat, args.ap_offset);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xsbmv.hpp
+++ b/test/routines/level2/xsbmv.hpp
@@ -45,6 +45,8 @@ class TestXsbmv {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXsbmv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXsbmv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.kl, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc, args.beta,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc, args.beta,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xspmv.hpp
+++ b/test/routines/level2/xspmv.hpp
@@ -45,6 +45,8 @@ class TestXspmv {
             kArgAPOffset, kArgXOffset, kArgYOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatAP, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXspmv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> ap_mat_cpu(args.ap_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.ap_mat.Read(queue, args.ap_size, ap_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXspmv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.alpha,
-                 ap_mat_cpu, args.ap_offset,
-                 x_vec_cpu, args.x_offset, args.x_inc, args.beta,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.ap_mat, args.ap_offset,
+                 buffers_host.x_vec, args.x_offset, args.x_inc, args.beta,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xspr.hpp
+++ b/test/routines/level2/xspr.hpp
@@ -45,6 +45,8 @@ class TestXspr {
             kArgAPOffset, kArgXOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatAP, kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatAP}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -106,17 +108,12 @@ class TestXspr {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> ap_mat_cpu(args.ap_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.ap_mat.Read(queue, args.ap_size, ap_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXspr(convertToCBLAS(args.layout),
                 convertToCBLAS(args.triangle),
                 args.n, args.alpha,
-                x_vec_cpu, args.x_offset, args.x_inc,
-                ap_mat_cpu, args.ap_offset);
-      buffers.ap_mat.Write(queue, args.ap_size, ap_mat_cpu);
+                buffers_host.x_vec, args.x_offset, args.x_inc,
+                buffers_host.ap_mat, args.ap_offset);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xspr2.hpp
+++ b/test/routines/level2/xspr2.hpp
@@ -45,6 +45,8 @@ class TestXspr2 {
             kArgAPOffset, kArgXOffset, kArgYOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatAP, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatAP}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXspr2 {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> ap_mat_cpu(args.ap_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.ap_mat.Read(queue, args.ap_size, ap_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXspr2(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.alpha,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc,
-                 ap_mat_cpu, args.ap_offset);
-      buffers.ap_mat.Write(queue, args.ap_size, ap_mat_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc,
+                 buffers_host.ap_mat, args.ap_offset);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xsymv.hpp
+++ b/test/routines/level2/xsymv.hpp
@@ -45,6 +45,8 @@ class TestXsymv {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecY}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXsymv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXsymv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc, args.beta,
-                 y_vec_cpu, args.y_offset, args.y_inc);
-      buffers.y_vec.Write(queue, args.y_size, y_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc, args.beta,
+                 buffers_host.y_vec, args.y_offset, args.y_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xsyr.hpp
+++ b/test/routines/level2/xsyr.hpp
@@ -45,6 +45,8 @@ class TestXsyr {
             kArgAOffset, kArgXOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatA}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -106,17 +108,12 @@ class TestXsyr {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXsyr(convertToCBLAS(args.layout),
                 convertToCBLAS(args.triangle),
                 args.n, args.alpha,
-                x_vec_cpu, args.x_offset, args.x_inc,
-                a_mat_cpu, args.a_offset, args.a_ld);
-      buffers.a_mat.Write(queue, args.a_size, a_mat_cpu);
+                buffers_host.x_vec, args.x_offset, args.x_inc,
+                buffers_host.a_mat, args.a_offset, args.a_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xsyr2.hpp
+++ b/test/routines/level2/xsyr2.hpp
@@ -45,6 +45,8 @@ class TestXsyr2 {
             kArgAOffset, kArgXOffset, kArgYOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX, kBufVecY}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatA}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -112,20 +114,13 @@ class TestXsyr2 {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      std::vector<T> y_vec_cpu(args.y_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
-      buffers.y_vec.Read(queue, args.y_size, y_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXsyr2(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  args.n, args.alpha,
-                 x_vec_cpu, args.x_offset, args.x_inc,
-                 y_vec_cpu, args.y_offset, args.y_inc,
-                 a_mat_cpu, args.a_offset, args.a_ld);
-      buffers.a_mat.Write(queue, args.a_size, a_mat_cpu);
+                 buffers_host.x_vec, args.x_offset, args.x_inc,
+                 buffers_host.y_vec, args.y_offset, args.y_inc,
+                 buffers_host.a_mat, args.a_offset, args.a_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xtbmv.hpp
+++ b/test/routines/level2/xtbmv.hpp
@@ -44,6 +44,8 @@ class TestXtbmv {
             kArgALeadDim, kArgXInc,
             kArgAOffset, kArgXOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecX}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -107,19 +109,14 @@ class TestXtbmv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXtbmv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  convertToCBLAS(args.a_transpose),
                  convertToCBLAS(args.diagonal),
                  args.n, args.kl,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc);
-      buffers.x_vec.Write(queue, args.x_size, x_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xtpmv.hpp
+++ b/test/routines/level2/xtpmv.hpp
@@ -44,6 +44,8 @@ class TestXtpmv {
             kArgXInc,
             kArgAPOffset, kArgXOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatAP, kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecX}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -107,19 +109,14 @@ class TestXtpmv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> ap_mat_cpu(args.ap_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.ap_mat.Read(queue, args.ap_size, ap_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXtpmv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  convertToCBLAS(args.a_transpose),
                  convertToCBLAS(args.diagonal),
                  args.n,
-                 ap_mat_cpu, args.ap_offset,
-                 x_vec_cpu, args.x_offset, args.x_inc);
-      buffers.x_vec.Write(queue, args.x_size, x_vec_cpu);
+                 buffers_host.ap_mat, args.ap_offset,
+                 buffers_host.x_vec, args.x_offset, args.x_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xtrmv.hpp
+++ b/test/routines/level2/xtrmv.hpp
@@ -44,6 +44,8 @@ class TestXtrmv {
             kArgALeadDim, kArgXInc,
             kArgAOffset, kArgXOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecX}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -107,19 +109,14 @@ class TestXtrmv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXtrmv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  convertToCBLAS(args.a_transpose),
                  convertToCBLAS(args.diagonal),
                  args.n,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc);
-      buffers.x_vec.Write(queue, args.x_size, x_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level2/xtrsv.hpp
+++ b/test/routines/level2/xtrsv.hpp
@@ -44,6 +44,8 @@ class TestXtrsv {
             kArgALeadDim, kArgXInc,
             kArgAOffset, kArgXOffset};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufVecX}; }
+  static std::vector<std::string> BuffersOut() { return {kBufVecX}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeX(const Arguments<T> &args) {
@@ -122,19 +124,14 @@ class TestXtrsv {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> x_vec_cpu(args.x_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.x_vec.Read(queue, args.x_size, x_vec_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXtrsv(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  convertToCBLAS(args.a_transpose),
                  convertToCBLAS(args.diagonal),
                  args.n,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 x_vec_cpu, args.x_offset, args.x_inc);
-      buffers.x_vec.Write(queue, args.x_size, x_vec_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.x_vec, args.x_offset, args.x_inc);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xgemm.hpp
+++ b/test/routines/level3/xgemm.hpp
@@ -45,6 +45,8 @@ class TestXgemm {
             kArgAOffset, kArgBOffset, kArgCOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatB, kBufMatC}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatC}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<T> &args) {
@@ -121,21 +123,14 @@ class TestXgemm {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> b_mat_cpu(args.b_size, static_cast<T>(0));
-      std::vector<T> c_mat_cpu(args.c_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.b_mat.Read(queue, args.b_size, b_mat_cpu);
-      buffers.c_mat.Read(queue, args.c_size, c_mat_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXgemm(convertToCBLAS(args.layout),
                  convertToCBLAS(args.a_transpose),
                  convertToCBLAS(args.b_transpose),
                  args.m, args.n, args.k, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 b_mat_cpu, args.b_offset, args.b_ld, args.beta,
-                 c_mat_cpu, args.c_offset, args.c_ld);
-      buffers.c_mat.Write(queue, args.c_size, c_mat_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.b_mat, args.b_offset, args.b_ld, args.beta,
+                 buffers_host.c_mat, args.c_offset, args.c_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xhemm.hpp
+++ b/test/routines/level3/xhemm.hpp
@@ -45,6 +45,8 @@ class TestXhemm {
             kArgAOffset, kArgBOffset, kArgCOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatB, kBufMatC}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatC}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<T> &args) {
@@ -121,21 +123,14 @@ class TestXhemm {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> b_mat_cpu(args.b_size, static_cast<T>(0));
-      std::vector<T> c_mat_cpu(args.c_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.b_mat.Read(queue, args.b_size, b_mat_cpu);
-      buffers.c_mat.Read(queue, args.c_size, c_mat_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXhemm(convertToCBLAS(args.layout),
                  convertToCBLAS(args.side),
                  convertToCBLAS(args.triangle),
                  args.m, args.n, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 b_mat_cpu, args.b_offset, args.b_ld, args.beta,
-                 c_mat_cpu, args.c_offset, args.c_ld);
-      buffers.c_mat.Write(queue, args.c_size, c_mat_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.b_mat, args.b_offset, args.b_ld, args.beta,
+                 buffers_host.c_mat, args.c_offset, args.c_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xher2k.hpp
+++ b/test/routines/level3/xher2k.hpp
@@ -45,6 +45,8 @@ class TestXher2k {
             kArgAOffset, kArgBOffset, kArgCOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatB, kBufMatC}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatC}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<U> &args) {
@@ -121,22 +123,15 @@ class TestXher2k {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<U> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> b_mat_cpu(args.b_size, static_cast<T>(0));
-      std::vector<T> c_mat_cpu(args.c_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.b_mat.Read(queue, args.b_size, b_mat_cpu);
-      buffers.c_mat.Read(queue, args.c_size, c_mat_cpu);
+    static StatusCode RunReference2(const Arguments<U> &args, BuffersHost<T> &buffers_host, Queue&) {
       auto alpha2 = T{args.alpha, args.alpha};
       cblasXher2k(convertToCBLAS(args.layout),
                   convertToCBLAS(args.triangle),
                   convertToCBLAS(args.a_transpose),
                   args.n, args.k, alpha2,
-                  a_mat_cpu, args.a_offset, args.a_ld,
-                  b_mat_cpu, args.b_offset, args.b_ld, args.beta,
-                  c_mat_cpu, args.c_offset, args.c_ld);
-      buffers.c_mat.Write(queue, args.c_size, c_mat_cpu);
+                  buffers_host.a_mat, args.a_offset, args.a_ld,
+                  buffers_host.b_mat, args.b_offset, args.b_ld, args.beta,
+                  buffers_host.c_mat, args.c_offset, args.c_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xherk.hpp
+++ b/test/routines/level3/xherk.hpp
@@ -45,6 +45,8 @@ class TestXherk {
             kArgAOffset, kArgCOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatC}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatC}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<U> &args) {
@@ -110,18 +112,13 @@ class TestXherk {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<U> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> c_mat_cpu(args.c_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.c_mat.Read(queue, args.c_size, c_mat_cpu);
+    static StatusCode RunReference2(const Arguments<U> &args, BuffersHost<T> &buffers_host, Queue&) {
       cblasXherk(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  convertToCBLAS(args.a_transpose),
                  args.n, args.k, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld, args.beta,
-                 c_mat_cpu, args.c_offset, args.c_ld);
-      buffers.c_mat.Write(queue, args.c_size, c_mat_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld, args.beta,
+                 buffers_host.c_mat, args.c_offset, args.c_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xsymm.hpp
+++ b/test/routines/level3/xsymm.hpp
@@ -45,6 +45,8 @@ class TestXsymm {
             kArgAOffset, kArgBOffset, kArgCOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatB, kBufMatC}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatC}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<T> &args) {
@@ -121,21 +123,14 @@ class TestXsymm {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> b_mat_cpu(args.b_size, static_cast<T>(0));
-      std::vector<T> c_mat_cpu(args.c_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.b_mat.Read(queue, args.b_size, b_mat_cpu);
-      buffers.c_mat.Read(queue, args.c_size, c_mat_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXsymm(convertToCBLAS(args.layout),
                  convertToCBLAS(args.side),
                  convertToCBLAS(args.triangle),
                  args.m, args.n, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 b_mat_cpu, args.b_offset, args.b_ld, args.beta,
-                 c_mat_cpu, args.c_offset, args.c_ld);
-      buffers.c_mat.Write(queue, args.c_size, c_mat_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.b_mat, args.b_offset, args.b_ld, args.beta,
+                 buffers_host.c_mat, args.c_offset, args.c_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xsyr2k.hpp
+++ b/test/routines/level3/xsyr2k.hpp
@@ -45,6 +45,8 @@ class TestXsyr2k {
             kArgAOffset, kArgBOffset, kArgCOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatB, kBufMatC}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatC}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<T> &args) {
@@ -119,21 +121,14 @@ class TestXsyr2k {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> b_mat_cpu(args.b_size, static_cast<T>(0));
-      std::vector<T> c_mat_cpu(args.c_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.b_mat.Read(queue, args.b_size, b_mat_cpu);
-      buffers.c_mat.Read(queue, args.c_size, c_mat_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXsyr2k(convertToCBLAS(args.layout),
                   convertToCBLAS(args.triangle),
                   convertToCBLAS(args.a_transpose),
                   args.n, args.k, args.alpha,
-                  a_mat_cpu, args.a_offset, args.a_ld,
-                  b_mat_cpu, args.b_offset, args.b_ld, args.beta,
-                  c_mat_cpu, args.c_offset, args.c_ld);
-      buffers.c_mat.Write(queue, args.c_size, c_mat_cpu);
+                  buffers_host.a_mat, args.a_offset, args.a_ld,
+                  buffers_host.b_mat, args.b_offset, args.b_ld, args.beta,
+                  buffers_host.c_mat, args.c_offset, args.c_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xsyrk.hpp
+++ b/test/routines/level3/xsyrk.hpp
@@ -45,6 +45,8 @@ class TestXsyrk {
             kArgAOffset, kArgCOffset,
             kArgAlpha, kArgBeta};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatC}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatC}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<T> &args) {
@@ -110,18 +112,13 @@ class TestXsyrk {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> c_mat_cpu(args.c_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.c_mat.Read(queue, args.c_size, c_mat_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXsyrk(convertToCBLAS(args.layout),
                  convertToCBLAS(args.triangle),
                  convertToCBLAS(args.a_transpose),
                  args.n, args.k, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld, args.beta,
-                 c_mat_cpu, args.c_offset, args.c_ld);
-      buffers.c_mat.Write(queue, args.c_size, c_mat_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld, args.beta,
+                 buffers_host.c_mat, args.c_offset, args.c_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xtrmm.hpp
+++ b/test/routines/level3/xtrmm.hpp
@@ -45,6 +45,8 @@ class TestXtrmm {
             kArgAOffset, kArgBOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatB}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatB}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<T> &args) {
@@ -112,20 +114,15 @@ class TestXtrmm {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> b_mat_cpu(args.b_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.b_mat.Read(queue, args.b_size, b_mat_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXtrmm(convertToCBLAS(args.layout),
                  convertToCBLAS(args.side),
                  convertToCBLAS(args.triangle),
                  convertToCBLAS(args.a_transpose),
                  convertToCBLAS(args.diagonal),
                  args.m, args.n, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 b_mat_cpu, args.b_offset, args.b_ld);
-      buffers.b_mat.Write(queue, args.b_size, b_mat_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.b_mat, args.b_offset, args.b_ld);
       return StatusCode::kSuccess;
     }
   #endif

--- a/test/routines/level3/xtrsm.hpp
+++ b/test/routines/level3/xtrsm.hpp
@@ -47,6 +47,8 @@ class TestXtrsm {
             kArgAOffset, kArgBOffset,
             kArgAlpha};
   }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatB}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatB}; }
 
   // Describes how to obtain the sizes of the buffers
   static size_t GetSizeA(const Arguments<T> &args) {
@@ -124,20 +126,15 @@ class TestXtrsm {
 
   // Describes how to run the CPU BLAS routine (for correctness/performance comparison)
   #ifdef CLBLAST_REF_CBLAS
-    static StatusCode RunReference2(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
-      std::vector<T> a_mat_cpu(args.a_size, static_cast<T>(0));
-      std::vector<T> b_mat_cpu(args.b_size, static_cast<T>(0));
-      buffers.a_mat.Read(queue, args.a_size, a_mat_cpu);
-      buffers.b_mat.Read(queue, args.b_size, b_mat_cpu);
+    static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue &) {
       cblasXtrsm(convertToCBLAS(args.layout),
                  convertToCBLAS(args.side),
                  convertToCBLAS(args.triangle),
                  convertToCBLAS(args.a_transpose),
                  convertToCBLAS(args.diagonal),
                  args.m, args.n, args.alpha,
-                 a_mat_cpu, args.a_offset, args.a_ld,
-                 b_mat_cpu, args.b_offset, args.b_ld);
-      buffers.b_mat.Write(queue, args.b_size, b_mat_cpu);
+                 buffers_host.a_mat, args.a_offset, args.a_ld,
+                 buffers_host.b_mat, args.b_offset, args.b_ld);
       return StatusCode::kSuccess;
     }
   #endif


### PR DESCRIPTION
Separated host-device and device-host memory copies from execution of the CBLAS reference code; for fair timing and code de-duplication