### PR TITLE
changing "wb" to "w" when saving json file (text mode)

### DIFF
--- a/scripts/benchmark/benchmark.py
+++ b/scripts/benchmark/benchmark.py
@@ -120,7 +120,7 @@ def benchmark_single(benchmark, platform, device, num_runs, precision, load_from
 
         # Stores the results to disk
         print("[benchmark] Saving benchmark results to '" + json_file_name + "'")
-        with open(json_file_name, "wb") as f:
+        with open(json_file_name, "w") as f:
             json.dump(results, f, sort_keys=True, indent=4)
 
     # Retrieves the data from the benchmark settings

--- a/scripts/database/database/io.py
+++ b/scripts/database/database/io.py
@@ -32,7 +32,7 @@ def load_database(filename):
 def save_database(database, filename):
     """Saves a database to disk"""
     print("[database] Saving database to '" + filename + "'")
-    with open(filename, "wb") as f:
+    with open(filename, "w") as f:
         json.dump(database, f, sort_keys=True, indent=4)
 
 


### PR DESCRIPTION
Hi Cedric,
I encountered a problem when using Anaconda Python 3 on Windows when recording json files. I had to change "wb" to "w" in 2 files when saving json file (text mode) - it seems to be working with both Python 2 and Python 3. Hope it's correct and of any help ;) ...
Thanks,
Grigori
