### PR TITLE
Fixes inability to run GEMM on multiple identical GPUs (issue #155)

### DIFF
--- a/src/cache.hpp
+++ b/src/cache.hpp
@@ -79,7 +79,7 @@ extern template std::string BinaryCache::Get(const BinaryKeyRef &, bool *) const
 // =================================================================================================
 
 // The key struct for the cache of compiled OpenCL programs (context-dependent)
-// Order of fields: context, precision, routine_name (smaller fields first)
+// Order of fields: context, device_id, precision, routine_name (smaller fields first)
 typedef std::tuple<cl_context, cl_device_id, Precision, std::string> ProgramKey;
 typedef std::tuple<const cl_context &, const cl_device_id &, const Precision &, const std::string &> ProgramKeyRef;
 

--- a/src/cache.hpp
+++ b/src/cache.hpp
@@ -80,8 +80,8 @@ extern template std::string BinaryCache::Get(const BinaryKeyRef &, bool *) const
 
 // The key struct for the cache of compiled OpenCL programs (context-dependent)
 // Order of fields: context, precision, routine_name (smaller fields first)
-typedef std::tuple<cl_context, Precision, std::string> ProgramKey;
-typedef std::tuple<const cl_context &, const Precision &, const std::string &> ProgramKeyRef;
+typedef std::tuple<cl_context, cl_device_id, Precision, std::string> ProgramKey;
+typedef std::tuple<const cl_context &, const cl_device_id &, const Precision &, const std::string &> ProgramKeyRef;
 
 typedef Cache<ProgramKey, Program> ProgramCache;
 

--- a/src/clblast.cpp
+++ b/src/clblast.cpp
@@ -2470,7 +2470,7 @@ StatusCode OverrideParameters(const cl_device_id device, const std::string &kern
     // Clears the existing program & binary cache for routines with the target kernel
     const auto routine_names = Routine::routines_by_kernel.at(kernel_name);
     for (const auto &routine_name : routine_names) {
-      ProgramCache::Instance().RemoveBySubset<1, 2>(ProgramKey{nullptr, precision, routine_name});
+      ProgramCache::Instance().RemoveBySubset<1, 2>(ProgramKey{nullptr, device, precision, routine_name});
       BinaryCache::Instance().Remove(BinaryKey{precision, routine_name, device_name});
     }
 

--- a/src/routine.cpp
+++ b/src/routine.cpp
@@ -87,7 +87,7 @@ void Routine::InitProgram(std::initializer_list<const char *> source) {
 
   // Queries the cache to see whether or not the program (context-specific) is already there
   bool has_program;
-  program_ = ProgramCache::Instance().Get(ProgramKeyRef{ context_(), precision_, routine_name_ },
+  program_ = ProgramCache::Instance().Get(ProgramKeyRef{ context_(), device_(), precision_, routine_name_ },
                                           &has_program);
   if (has_program) { return; }
 
@@ -106,7 +106,7 @@ void Routine::InitProgram(std::initializer_list<const char *> source) {
   if (has_binary) {
     program_ = Program(device_, context_, binary);
     program_.Build(device_, options);
-    ProgramCache::Instance().Store(ProgramKey{ context_(), precision_, routine_name_ },
+    ProgramCache::Instance().Store(ProgramKey{ context_(), device_(), precision_, routine_name_ },
                                    Program{ program_ });
     return;
   }
@@ -185,7 +185,7 @@ void Routine::InitProgram(std::initializer_list<const char *> source) {
   BinaryCache::Instance().Store(BinaryKey{ precision_, routine_name_, device_name_ },
                                 program_.GetIR());
 
-  ProgramCache::Instance().Store(ProgramKey{ context_(), precision_, routine_name_ },
+  ProgramCache::Instance().Store(ProgramKey{ context_(), device_(), precision_, routine_name_ },
                                  Program{ program_ });
 
   // Prints the elapsed compilation time in case of debugging in verbose mode


### PR DESCRIPTION
Hi,
I tested this change both with the initial test I wrote for #155 and CLBlast's own tests. All tested but one passed. clblast_test_xtrsm has failed, but it it was failing even before my patch, so I guess it's something unrelated.

```
Test project /home/kpot/sources/clbuild
      Start  1: clblast_test_xswap
 1/46 Test  #1: clblast_test_xswap .................   Passed    1.68 sec
      Start  2: clblast_test_xscal
 2/46 Test  #2: clblast_test_xscal .................   Passed    1.00 sec
      Start  3: clblast_test_xcopy
 3/46 Test  #3: clblast_test_xcopy .................   Passed    1.16 sec
      Start  4: clblast_test_xaxpy
 4/46 Test  #4: clblast_test_xaxpy .................   Passed    1.69 sec
      Start  5: clblast_test_xdot
 5/46 Test  #5: clblast_test_xdot ..................   Passed    0.87 sec
      Start  6: clblast_test_xdotu
 6/46 Test  #6: clblast_test_xdotu .................   Passed    0.93 sec
      Start  7: clblast_test_xdotc
 7/46 Test  #7: clblast_test_xdotc .................   Passed    0.89 sec
      Start  8: clblast_test_xnrm2
 8/46 Test  #8: clblast_test_xnrm2 .................   Passed    1.09 sec
      Start  9: clblast_test_xasum
 9/46 Test  #9: clblast_test_xasum .................   Passed    1.08 sec
      Start 10: clblast_test_xamax
10/46 Test #10: clblast_test_xamax .................   Passed    1.15 sec
      Start 11: clblast_test_xgemv
11/46 Test #11: clblast_test_xgemv .................   Passed    6.44 sec
      Start 12: clblast_test_xgbmv
12/46 Test #12: clblast_test_xgbmv .................   Passed   20.45 sec
      Start 13: clblast_test_xhemv
13/46 Test #13: clblast_test_xhemv .................   Passed    4.75 sec
      Start 14: clblast_test_xhbmv
14/46 Test #14: clblast_test_xhbmv .................   Passed    7.85 sec
      Start 15: clblast_test_xhpmv
15/46 Test #15: clblast_test_xhpmv .................   Passed    5.14 sec
      Start 16: clblast_test_xsymv
16/46 Test #16: clblast_test_xsymv .................   Passed    3.14 sec
      Start 17: clblast_test_xsbmv
17/46 Test #17: clblast_test_xsbmv .................   Passed    8.67 sec
      Start 18: clblast_test_xspmv
18/46 Test #18: clblast_test_xspmv .................   Passed    4.46 sec
      Start 19: clblast_test_xtrmv
19/46 Test #19: clblast_test_xtrmv .................   Passed   21.16 sec
      Start 20: clblast_test_xtbmv
20/46 Test #20: clblast_test_xtbmv .................   Passed   16.14 sec
      Start 21: clblast_test_xtpmv
21/46 Test #21: clblast_test_xtpmv .................   Passed   10.86 sec
      Start 22: clblast_test_xtrsv
22/46 Test #22: clblast_test_xtrsv .................   Passed    7.48 sec
      Start 23: clblast_test_xger
23/46 Test #23: clblast_test_xger ..................   Passed    1.38 sec
      Start 24: clblast_test_xgeru
24/46 Test #24: clblast_test_xgeru .................   Passed    1.74 sec
      Start 25: clblast_test_xgerc
25/46 Test #25: clblast_test_xgerc .................   Passed    1.73 sec
      Start 26: clblast_test_xher
26/46 Test #26: clblast_test_xher ..................   Passed    1.06 sec
      Start 27: clblast_test_xhpr
27/46 Test #27: clblast_test_xhpr ..................   Passed    0.90 sec
      Start 28: clblast_test_xher2
28/46 Test #28: clblast_test_xher2 .................   Passed    1.82 sec
      Start 29: clblast_test_xhpr2
29/46 Test #29: clblast_test_xhpr2 .................   Passed    1.30 sec
      Start 30: clblast_test_xsyr
30/46 Test #30: clblast_test_xsyr ..................   Passed    0.94 sec
      Start 31: clblast_test_xspr
31/46 Test #31: clblast_test_xspr ..................   Passed    0.84 sec
      Start 32: clblast_test_xsyr2
32/46 Test #32: clblast_test_xsyr2 .................   Passed    1.35 sec
      Start 33: clblast_test_xspr2
33/46 Test #33: clblast_test_xspr2 .................   Passed    1.08 sec
      Start 34: clblast_test_xgemm
34/46 Test #34: clblast_test_xgemm .................   Passed    7.65 sec
      Start 35: clblast_test_xsymm
35/46 Test #35: clblast_test_xsymm .................   Passed    5.86 sec
      Start 36: clblast_test_xhemm
36/46 Test #36: clblast_test_xhemm .................   Passed    3.62 sec
      Start 37: clblast_test_xsyrk
37/46 Test #37: clblast_test_xsyrk .................   Passed    3.58 sec
      Start 38: clblast_test_xherk
38/46 Test #38: clblast_test_xherk .................   Passed    1.94 sec
      Start 39: clblast_test_xsyr2k
39/46 Test #39: clblast_test_xsyr2k ................   Passed    4.29 sec
      Start 40: clblast_test_xher2k
40/46 Test #40: clblast_test_xher2k ................   Passed    2.17 sec
      Start 41: clblast_test_xtrmm
41/46 Test #41: clblast_test_xtrmm .................   Passed    9.48 sec
      Start 42: clblast_test_xtrsm
42/46 Test #42: clblast_test_xtrsm .................***Exception: SegFault209.57 sec
      Start 43: clblast_test_xomatcopy
43/46 Test #43: clblast_test_xomatcopy .............   Passed   14.87 sec
      Start 44: clblast_test_xaxpybatched
44/46 Test #44: clblast_test_xaxpybatched ..........   Passed    2.34 sec
      Start 45: clblast_test_xgemmbatched


45/46 Test #45: clblast_test_xgemmbatched ..........   Passed   17.73 sec
      Start 46: clblast_test_override_parameters
46/46 Test #46: clblast_test_override_parameters ...   Passed    7.36 sec

98% tests passed, 1 tests failed out of 46

Total Test time (real) = 433.21 sec

The following tests FAILED:
	 42 - clblast_test_xtrsm (SEGFAULT)
Errors while running CTest

```