### PR TITLE
im2col

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 
+Development (next version)
+- Added non-BLAS routines:
+  * SIM2COL/DIM2COL/CIM2COL/ZIM2COL/HIM2COL (im2col transform as used to express convolution as GEMM)
+
 Version 1.0.1
-- Fixed a bug in the direct version of the GEMM kernel
+- Fixed a bug in the direct version of the GEMM kernel)
 
 Version 1.0.0
 - Fixed a bug in the TRSM routine for alpha != 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ set(LEVEL1_ROUTINES xswap xscal xcopy xaxpy xdot xdotu xdotc xnrm2 xasum xamax)
 set(LEVEL2_ROUTINES xgemv xgbmv xhemv xhbmv xhpmv xsymv xsbmv xspmv xtrmv xtbmv xtpmv xtrsv
                     xger xgeru xgerc xher xhpr xher2 xhpr2 xsyr xspr xsyr2 xspr2)
 set(LEVEL3_ROUTINES xgemm xsymm xhemm xsyrk xherk xsyr2k xher2k xtrmm xtrsm)
-set(LEVELX_ROUTINES xomatcopy xaxpybatched xgemmbatched)
+set(LEVELX_ROUTINES xomatcopy xim2col xaxpybatched xgemmbatched)
 set(ROUTINES ${LEVEL1_ROUTINES} ${LEVEL2_ROUTINES} ${LEVEL3_ROUTINES} ${LEVELX_ROUTINES})
 set(PRECISIONS 32 64 3232 6464 16)
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ In addition, some extra non-BLAS routines are also supported by CLBlast, classif
 | IxMAX      | ✔ | ✔ | ✔ | ✔ | ✔ |
 | IxMIN      | ✔ | ✔ | ✔ | ✔ | ✔ |
 | xOMATCOPY  | ✔ | ✔ | ✔ | ✔ | ✔ |
+| xIM2COL    | ✔ | ✔ | ✔ | ✔ | ✔ |
 
 Some less commonly used BLAS routines are not yet supported yet by CLBlast. They are xROTG, xROTMG, xROT, xROTM, xTBSV, and xTPSV.
 

--- a/doc/clblast.md
+++ b/doc/clblast.md
@@ -2956,6 +2956,66 @@ Requirements for OMATCOPY:
 
 
 
+xIM2COL: Im2col function (non-BLAS function)
+-------------
+
+Performs the im2col algorithm, in which _im_ is the input matrix and _col_ is the output matrix.
+
+C++ API:
+```
+template <typename T>
+StatusCode Im2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                  const cl_mem im_buffer, const size_t im_offset,
+                  cl_mem col_buffer, const size_t col_offset,
+                  cl_command_queue* queue, cl_event* event)
+```
+
+C API:
+```
+CLBlastStatusCode CLBlastSim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event)
+CLBlastStatusCode CLBlastDim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event)
+CLBlastStatusCode CLBlastCim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event)
+CLBlastStatusCode CLBlastZim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event)
+CLBlastStatusCode CLBlastHim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event)
+```
+
+Arguments to IM2COL:
+
+* `const size_t channels`: Integer size argument. This value must be positive.
+* `const size_t height`: Integer size argument. This value must be positive.
+* `const size_t width`: Integer size argument. This value must be positive.
+* `const size_t kernel_h`: Integer size argument. This value must be positive.
+* `const size_t kernel_w`: Integer size argument. This value must be positive.
+* `const size_t pad_h`: Integer size argument. This value must be positive.
+* `const size_t pad_w`: Integer size argument. This value must be positive.
+* `const size_t stride_h`: Integer size argument. This value must be positive.
+* `const size_t stride_w`: Integer size argument. This value must be positive.
+* `const size_t dilation_h`: Integer size argument. This value must be positive.
+* `const size_t dilation_w`: Integer size argument. This value must be positive.
+* `const cl_mem im_buffer`: OpenCL buffer to store the input im vector.
+* `const size_t im_offset`: The offset in elements from the start of the input im vector.
+* `cl_mem col_buffer`: OpenCL buffer to store the output col vector.
+* `const size_t col_offset`: The offset in elements from the start of the output col vector.
+* `cl_command_queue* queue`: Pointer to an OpenCL command queue associated with a context and device to execute the routine on.
+* `cl_event* event`: Pointer to an OpenCL event to be able to wait for completion of the routine's OpenCL kernel(s). This is an optional argument.
+
+
+
 xAXPYBATCHED: Batched version of AXPY
 -------------
 

--- a/include/clblast.h
+++ b/include/clblast.h
@@ -617,6 +617,13 @@ StatusCode Omatcopy(const Layout layout, const Transpose a_transpose,
                     cl_mem b_buffer, const size_t b_offset, const size_t b_ld,
                     cl_command_queue* queue, cl_event* event = nullptr);
 
+// Im2col function (non-BLAS function): SIM2COL/DIM2COL/CIM2COL/ZIM2COL/HIM2COL
+template <typename T>
+StatusCode Im2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                  const cl_mem im_buffer, const size_t im_offset,
+                  cl_mem col_buffer, const size_t col_offset,
+                  cl_command_queue* queue, cl_event* event = nullptr);
+
 // Batched version of AXPY: SAXPYBATCHED/DAXPYBATCHED/CAXPYBATCHED/ZAXPYBATCHED/HAXPYBATCHED
 template <typename T>
 StatusCode AxpyBatched(const size_t n,

--- a/include/clblast_c.h
+++ b/include/clblast_c.h
@@ -1350,6 +1350,28 @@ CLBlastStatusCode PUBLIC_API CLBlastHomatcopy(const CLBlastLayout layout, const 
                                               cl_mem b_buffer, const size_t b_offset, const size_t b_ld,
                                               cl_command_queue* queue, cl_event* event);
 
+// Im2col function (non-BLAS function): SIM2COL/DIM2COL/CIM2COL/ZIM2COL/HIM2COL
+CLBlastStatusCode PUBLIC_API CLBlastSim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                            const cl_mem im_buffer, const size_t im_offset,
+                                            cl_mem col_buffer, const size_t col_offset,
+                                            cl_command_queue* queue, cl_event* event);
+CLBlastStatusCode PUBLIC_API CLBlastDim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                            const cl_mem im_buffer, const size_t im_offset,
+                                            cl_mem col_buffer, const size_t col_offset,
+                                            cl_command_queue* queue, cl_event* event);
+CLBlastStatusCode PUBLIC_API CLBlastCim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                            const cl_mem im_buffer, const size_t im_offset,
+                                            cl_mem col_buffer, const size_t col_offset,
+                                            cl_command_queue* queue, cl_event* event);
+CLBlastStatusCode PUBLIC_API CLBlastZim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                            const cl_mem im_buffer, const size_t im_offset,
+                                            cl_mem col_buffer, const size_t col_offset,
+                                            cl_command_queue* queue, cl_event* event);
+CLBlastStatusCode PUBLIC_API CLBlastHim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                            const cl_mem im_buffer, const size_t im_offset,
+                                            cl_mem col_buffer, const size_t col_offset,
+                                            cl_command_queue* queue, cl_event* event);
+
 // Batched version of AXPY: SAXPYBATCHED/DAXPYBATCHED/CAXPYBATCHED/ZAXPYBATCHED/HAXPYBATCHED
 CLBlastStatusCode PUBLIC_API CLBlastSaxpyBatched(const size_t n,
                                                  const float *alphas,

--- a/include/clblast_netlib_c.h
+++ b/include/clblast_netlib_c.h
@@ -920,6 +920,20 @@ void PUBLIC_API cblas_zomatcopy(const CLBlastLayout layout, const CLBlastTranspo
                                 const void* a, const int a_ld,
                                 void* b, const int b_ld);
 
+// Im2col function (non-BLAS function): SIM2COL/DIM2COL/CIM2COL/ZIM2COL/HIM2COL
+void PUBLIC_API cblas_sim2col(const int channels, const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h, const int pad_w, const int stride_h, const int stride_w, const int dilation_h, const int dilation_w,
+                              const float* im,
+                              float* col);
+void PUBLIC_API cblas_dim2col(const int channels, const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h, const int pad_w, const int stride_h, const int stride_w, const int dilation_h, const int dilation_w,
+                              const double* im,
+                              double* col);
+void PUBLIC_API cblas_cim2col(const int channels, const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h, const int pad_w, const int stride_h, const int stride_w, const int dilation_h, const int dilation_w,
+                              const void* im,
+                              void* col);
+void PUBLIC_API cblas_zim2col(const int channels, const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h, const int pad_w, const int stride_h, const int stride_w, const int dilation_h, const int dilation_w,
+                              const void* im,
+                              void* col);
+
 // =================================================================================================
 
 #ifdef __cplusplus

--- a/scripts/generator/generator/routine.py
+++ b/scripts/generator/generator/routine.py
@@ -182,7 +182,7 @@ class Routine:
 
     def buffers_without_ld_inc(self):
         """List of buffers without 'inc' or 'ld'"""
-        return self.scalar_buffers_first() + self.scalar_buffers_second() + ["ap"]
+        return self.scalar_buffers_first() + self.scalar_buffers_second() + ["ap", "im", "col"]
 
     def get_buffer_type(self, name, flavour):
         if name in self.index_buffers():
@@ -195,7 +195,7 @@ class Routine:
 
     def no_scalars(self):
         """Determines whether or not this routine has scalar arguments (alpha/beta)"""
-        return self.scalars == []
+        return self.scalars == [] or self.name == "im2col"
 
     def has_layout(self):
         """Determines whether the layout is an argument"""
@@ -216,12 +216,12 @@ class Routine:
         """Determines which buffers go first (between alpha and beta) and which ones go after"""
         if self.level == "2b":
             return ["x", "y"]
-        return ["ap", "a", "b", "x"]
+        return ["ap", "a", "b", "x", "im"]
 
     def buffers_second(self):
         if self.level == "2b":
             return ["ap", "a", "b", "c"]
-        return ["y", "c"]
+        return ["y", "c", "col"]
 
     def buffer(self, name):
         """Retrieves a variable name for a specific input/output vector/matrix (e.g. 'x')"""

--- a/src/clblast.cpp
+++ b/src/clblast.cpp
@@ -72,6 +72,7 @@
 
 // Level-x includes (non-BLAS)
 #include "routines/levelx/xomatcopy.hpp"
+#include "routines/levelx/xim2col.hpp"
 #include "routines/levelx/xaxpybatched.hpp"
 #include "routines/levelx/xgemmbatched.hpp"
 
@@ -2211,6 +2212,42 @@ template StatusCode PUBLIC_API Omatcopy<half>(const Layout, const Transpose,
                                               const cl_mem, const size_t, const size_t,
                                               cl_mem, const size_t, const size_t,
                                               cl_command_queue*, cl_event*);
+
+// Im2col function (non-BLAS function): SIM2COL/DIM2COL/CIM2COL/ZIM2COL/HIM2COL
+template <typename T>
+StatusCode Im2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                  const cl_mem im_buffer, const size_t im_offset,
+                  cl_mem col_buffer, const size_t col_offset,
+                  cl_command_queue* queue, cl_event* event) {
+  try {
+    auto queue_cpp = Queue(*queue);
+    auto routine = Xim2col<T>(queue_cpp, event);
+    routine.DoIm2col(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                     Buffer<T>(im_buffer), im_offset,
+                     Buffer<T>(col_buffer), col_offset);
+    return StatusCode::kSuccess;
+  } catch (...) { return DispatchException(); }
+}
+template StatusCode PUBLIC_API Im2col<float>(const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t,
+                                             const cl_mem, const size_t,
+                                             cl_mem, const size_t,
+                                             cl_command_queue*, cl_event*);
+template StatusCode PUBLIC_API Im2col<double>(const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t,
+                                              const cl_mem, const size_t,
+                                              cl_mem, const size_t,
+                                              cl_command_queue*, cl_event*);
+template StatusCode PUBLIC_API Im2col<float2>(const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t,
+                                              const cl_mem, const size_t,
+                                              cl_mem, const size_t,
+                                              cl_command_queue*, cl_event*);
+template StatusCode PUBLIC_API Im2col<double2>(const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t,
+                                               const cl_mem, const size_t,
+                                               cl_mem, const size_t,
+                                               cl_command_queue*, cl_event*);
+template StatusCode PUBLIC_API Im2col<half>(const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t, const size_t,
+                                            const cl_mem, const size_t,
+                                            cl_mem, const size_t,
+                                            cl_command_queue*, cl_event*);
 
 // Batched version of AXPY: SAXPYBATCHED/DAXPYBATCHED/CAXPYBATCHED/ZAXPYBATCHED/HAXPYBATCHED
 template <typename T>

--- a/src/clblast_c.cpp
+++ b/src/clblast_c.cpp
@@ -3515,6 +3515,73 @@ CLBlastStatusCode CLBlastHomatcopy(const CLBlastLayout layout, const CLBlastTran
   } catch (...) { return static_cast<CLBlastStatusCode>(clblast::DispatchExceptionForC()); }
 }
 
+// IM2COL
+CLBlastStatusCode CLBlastSim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event) {
+  try {
+    return static_cast<CLBlastStatusCode>(
+      clblast::Im2col<float>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                             im_buffer, im_offset,
+                             col_buffer, col_offset,
+                             queue, event)
+    );
+  } catch (...) { return static_cast<CLBlastStatusCode>(clblast::DispatchExceptionForC()); }
+}
+CLBlastStatusCode CLBlastDim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event) {
+  try {
+    return static_cast<CLBlastStatusCode>(
+      clblast::Im2col<double>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                              im_buffer, im_offset,
+                              col_buffer, col_offset,
+                              queue, event)
+    );
+  } catch (...) { return static_cast<CLBlastStatusCode>(clblast::DispatchExceptionForC()); }
+}
+CLBlastStatusCode CLBlastCim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event) {
+  try {
+    return static_cast<CLBlastStatusCode>(
+      clblast::Im2col<float2>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                              im_buffer, im_offset,
+                              col_buffer, col_offset,
+                              queue, event)
+    );
+  } catch (...) { return static_cast<CLBlastStatusCode>(clblast::DispatchExceptionForC()); }
+}
+CLBlastStatusCode CLBlastZim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event) {
+  try {
+    return static_cast<CLBlastStatusCode>(
+      clblast::Im2col<double2>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                               im_buffer, im_offset,
+                               col_buffer, col_offset,
+                               queue, event)
+    );
+  } catch (...) { return static_cast<CLBlastStatusCode>(clblast::DispatchExceptionForC()); }
+}
+CLBlastStatusCode CLBlastHim2col(const size_t channels, const size_t height, const size_t width, const size_t kernel_h, const size_t kernel_w, const size_t pad_h, const size_t pad_w, const size_t stride_h, const size_t stride_w, const size_t dilation_h, const size_t dilation_w,
+                                 const cl_mem im_buffer, const size_t im_offset,
+                                 cl_mem col_buffer, const size_t col_offset,
+                                 cl_command_queue* queue, cl_event* event) {
+  try {
+    return static_cast<CLBlastStatusCode>(
+      clblast::Im2col<half>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                            im_buffer, im_offset,
+                            col_buffer, col_offset,
+                            queue, event)
+    );
+  } catch (...) { return static_cast<CLBlastStatusCode>(clblast::DispatchExceptionForC()); }
+}
+
 // AXPY
 CLBlastStatusCode CLBlastSaxpyBatched(const size_t n,
                                       const float *alphas,

--- a/src/clblast_netlib_c.cpp
+++ b/src/clblast_netlib_c.cpp
@@ -4735,4 +4735,94 @@ void cblas_zomatcopy(const CLBlastLayout layout, const CLBlastTranspose a_transp
   b_buffer.Read(queue, b_size, reinterpret_cast<double2*>(b));
 }
 
+// IM2COL
+void cblas_sim2col(const int channels, const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h, const int pad_w, const int stride_h, const int stride_w, const int dilation_h, const int dilation_w,
+                   const float* im,
+                   float* col) {
+  auto device = get_device();
+  auto context = clblast::Context(device);
+  auto queue = clblast::Queue(context, device);
+  const auto im_size = height * width * channels;
+  const auto col_size = height * width * channels;
+  auto im_buffer = clblast::Buffer<float>(context, im_size);
+  auto col_buffer = clblast::Buffer<float>(context, col_size);
+  im_buffer.Write(queue, im_size, reinterpret_cast<const float*>(im));
+  col_buffer.Write(queue, col_size, reinterpret_cast<float*>(col));
+  auto queue_cl = queue();
+  auto s = clblast::Im2col<float>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                                  im_buffer(), 0,
+                                  col_buffer(), 0,
+                                  &queue_cl);
+  if (s != clblast::StatusCode::kSuccess) {
+    throw std::runtime_error("CLBlast returned with error code " + clblast::ToString(s));
+  }
+  col_buffer.Read(queue, col_size, reinterpret_cast<float*>(col));
+}
+void cblas_dim2col(const int channels, const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h, const int pad_w, const int stride_h, const int stride_w, const int dilation_h, const int dilation_w,
+                   const double* im,
+                   double* col) {
+  auto device = get_device();
+  auto context = clblast::Context(device);
+  auto queue = clblast::Queue(context, device);
+  const auto im_size = height * width * channels;
+  const auto col_size = height * width * channels;
+  auto im_buffer = clblast::Buffer<double>(context, im_size);
+  auto col_buffer = clblast::Buffer<double>(context, col_size);
+  im_buffer.Write(queue, im_size, reinterpret_cast<const double*>(im));
+  col_buffer.Write(queue, col_size, reinterpret_cast<double*>(col));
+  auto queue_cl = queue();
+  auto s = clblast::Im2col<double>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                                   im_buffer(), 0,
+                                   col_buffer(), 0,
+                                   &queue_cl);
+  if (s != clblast::StatusCode::kSuccess) {
+    throw std::runtime_error("CLBlast returned with error code " + clblast::ToString(s));
+  }
+  col_buffer.Read(queue, col_size, reinterpret_cast<double*>(col));
+}
+void cblas_cim2col(const int channels, const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h, const int pad_w, const int stride_h, const int stride_w, const int dilation_h, const int dilation_w,
+                   const void* im,
+                   void* col) {
+  auto device = get_device();
+  auto context = clblast::Context(device);
+  auto queue = clblast::Queue(context, device);
+  const auto im_size = height * width * channels;
+  const auto col_size = height * width * channels;
+  auto im_buffer = clblast::Buffer<float2>(context, im_size);
+  auto col_buffer = clblast::Buffer<float2>(context, col_size);
+  im_buffer.Write(queue, im_size, reinterpret_cast<const float2*>(im));
+  col_buffer.Write(queue, col_size, reinterpret_cast<float2*>(col));
+  auto queue_cl = queue();
+  auto s = clblast::Im2col<float2>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                                   im_buffer(), 0,
+                                   col_buffer(), 0,
+                                   &queue_cl);
+  if (s != clblast::StatusCode::kSuccess) {
+    throw std::runtime_error("CLBlast returned with error code " + clblast::ToString(s));
+  }
+  col_buffer.Read(queue, col_size, reinterpret_cast<float2*>(col));
+}
+void cblas_zim2col(const int channels, const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h, const int pad_w, const int stride_h, const int stride_w, const int dilation_h, const int dilation_w,
+                   const void* im,
+                   void* col) {
+  auto device = get_device();
+  auto context = clblast::Context(device);
+  auto queue = clblast::Queue(context, device);
+  const auto im_size = height * width * channels;
+  const auto col_size = height * width * channels;
+  auto im_buffer = clblast::Buffer<double2>(context, im_size);
+  auto col_buffer = clblast::Buffer<double2>(context, col_size);
+  im_buffer.Write(queue, im_size, reinterpret_cast<const double2*>(im));
+  col_buffer.Write(queue, col_size, reinterpret_cast<double2*>(col));
+  auto queue_cl = queue();
+  auto s = clblast::Im2col<double2>(channels, height, width, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
+                                    im_buffer(), 0,
+                                    col_buffer(), 0,
+                                    &queue_cl);
+  if (s != clblast::StatusCode::kSuccess) {
+    throw std::runtime_error("CLBlast returned with error code " + clblast::ToString(s));
+  }
+  col_buffer.Read(queue, col_size, reinterpret_cast<double2*>(col));
+}
+
 // =================================================================================================

--- a/src/kernels/levelx/im2col.opencl
+++ b/src/kernels/levelx/im2col.opencl
@@ -1,0 +1,73 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file contains the im2col kernel.
+//
+// =================================================================================================
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+R"(
+
+// =================================================================================================
+
+#define WGS1 16
+#define WGS2 16
+
+__kernel __attribute__((reqd_work_group_size(WGS1, WGS2, 1)))
+void im2col(const int input_h, const int input_w,
+            const int output_h, const int output_w,
+            const int kernel_h, const int kernel_w,
+            const int pad_h, const int pad_w,
+            const int stride_h, const int stride_w,
+            const int dilation_h, const int dilation_w,
+            const __global real* restrict im_buffer, const int im_offset,
+            __global real* col_buffer, const int col_offset) {
+
+  // Thread IDs
+  const int h_id = get_global_id(0); // image height, max 'output_h'
+  const int w_id = get_global_id(1); // image width, max 'output_w'
+  const int c_id = get_global_id(2); // input channels
+  if (h_id < output_h && w_id < output_w) {
+
+    #pragma unroll
+    for (int kh_id = 0; kh_id < kernel_h; ++kh_id) { // kernel height
+      #pragma unroll
+      for (int kw_id = 0; kw_id < kernel_w; ++kw_id) { // kernel width
+
+        // Retrieves the input value
+        const int h_index = -pad_h + kh_id * dilation_h + stride_h * h_id;
+        const int w_index = -pad_w + kw_id * dilation_w + stride_w * w_id;
+        real val;
+        if (h_index >= 0 && h_index < input_h &&
+            w_index >= 0 && w_index < input_w) {
+          const int input_index = w_index + input_w * (h_index + input_h * c_id);
+          val = im_buffer[input_index + im_offset];
+        }
+        else {
+          SetToZero(val);
+        }
+
+        // Sets the output value
+        const int kernel_index = kw_id + kernel_w * kh_id;
+        const int patch_index = w_id + output_w * h_id;
+        const int output_index = patch_index + kernel_index * output_w * output_h +
+                                  c_id * output_w * output_h * kernel_h * kernel_w;
+        col_buffer[output_index + col_offset] = val;
+      }
+    }
+  }
+}
+
+// =================================================================================================
+
+// End of the C++11 raw string literal
+)"
+
+// =================================================================================================

--- a/src/kernels/levelx/im2col.opencl
+++ b/src/kernels/levelx/im2col.opencl
@@ -15,12 +15,17 @@
 // literal). Comment-out this line for syntax-highlighting when developing.
 R"(
 
+// Work-group size parameters re-used from the 'copy' kernel
+#ifndef COPY_DIMX
+  #define COPY_DIMX 8      // Local workgroup size in the first dimension (x)
+#endif
+#ifndef COPY_DIMY
+  #define COPY_DIMY 8      // Local workgroup size in the second dimension (y)
+#endif
+
 // =================================================================================================
 
-#define WGS1 16
-#define WGS2 16
-
-__kernel __attribute__((reqd_work_group_size(WGS1, WGS2, 1)))
+__kernel __attribute__((reqd_work_group_size(COPY_DIMX, COPY_DIMY, 1)))
 void im2col(const int input_h, const int input_w,
             const int output_h, const int output_w,
             const int kernel_h, const int kernel_w,
@@ -31,8 +36,8 @@ void im2col(const int input_h, const int input_w,
             __global real* col_buffer, const int col_offset) {
 
   // Thread IDs
-  const int h_id = get_global_id(0); // image height, max 'output_h'
-  const int w_id = get_global_id(1); // image width, max 'output_w'
+  const int w_id = get_global_id(0); // image width, max 'output_w'
+  const int h_id = get_global_id(1); // image height, max 'output_h'
   const int c_id = get_global_id(2); // input channels
   if (h_id < output_h && w_id < output_w) {
 

--- a/src/routines/levelx/xim2col.cpp
+++ b/src/routines/levelx/xim2col.cpp
@@ -1,0 +1,55 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the Xim2col class (see the header for information about the class).
+//
+// =================================================================================================
+
+#include "routines/levelx/xim2col.hpp"
+
+#include <string>
+#include <vector>
+
+namespace clblast {
+// =================================================================================================
+
+// Constructor: forwards to base class constructor
+template <typename T>
+Xim2col<T>::Xim2col(Queue &queue, EventPointer event, const std::string &name):
+        Routine(queue, event, name, {}, PrecisionValue<T>(), {}, {
+#include "../../kernels/level3/level3.opencl"
+        }) {
+}
+
+// =================================================================================================
+
+// The main routine
+template <typename T>
+void Xim2col<T>::DoIm2col(const size_t channels, const size_t height, const size_t width,
+                          const size_t kernel_h, const size_t kernel_w, const size_t pad_h,
+                          const size_t pad_w, const size_t stride_h, const size_t stride_w,
+                          const size_t dilation_h, const size_t dilation_w,
+                          const Buffer<T> &im_buffer, const size_t im_offset,
+                          const Buffer<T> &col_buffer, const size_t col_offset) {
+
+  // Makes sure all dimensions are larger than zero
+  if ((channels == 0) || (height == 0) || (width == 0)) { throw BLASError(StatusCode::kInvalidDimension); }
+}
+
+// =================================================================================================
+
+// Compiles the templated class
+template class Xim2col<half>;
+template class Xim2col<float>;
+template class Xim2col<double>;
+template class Xim2col<float2>;
+template class Xim2col<double2>;
+
+// =================================================================================================
+} // namespace clblast

--- a/src/routines/levelx/xim2col.cpp
+++ b/src/routines/levelx/xim2col.cpp
@@ -22,7 +22,7 @@ namespace clblast {
 // Constructor: forwards to base class constructor
 template <typename T>
 Xim2col<T>::Xim2col(Queue &queue, EventPointer event, const std::string &name):
-        Routine(queue, event, name, {}, PrecisionValue<T>(), {}, {
+        Routine(queue, event, name, {"Copy"}, PrecisionValue<T>(), {}, {
 #include "../../kernels/levelx/im2col.opencl"
         }) {
 }
@@ -71,10 +71,10 @@ void Xim2col<T>::DoIm2col(const size_t channels, const size_t height, const size
   kernel.SetArgument(15, static_cast<int>(col_offset));
 
   // Launches the kernel
-  const auto h_ceiled = Ceil(output_h, 16);
-  const auto w_ceiled = Ceil(output_w, 16);
-  auto global = std::vector<size_t>{h_ceiled, w_ceiled, channels};
-  auto local = std::vector<size_t>{16, 16, 1};
+  const auto w_ceiled = Ceil(output_w, db_["COPY_DIMY"]);
+  const auto h_ceiled = Ceil(output_h, db_["COPY_DIMX"]);
+  const auto global = std::vector<size_t>{w_ceiled, h_ceiled, channels};
+  const auto local = std::vector<size_t>{db_["COPY_DIMX"], db_["COPY_DIMY"], 1};
   RunKernel(kernel, queue_, device_, global, local, event_);
 }
 

--- a/src/routines/levelx/xim2col.hpp
+++ b/src/routines/levelx/xim2col.hpp
@@ -1,0 +1,44 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements the Xim2col routine. The precision is implemented using a template argument.
+//
+// =================================================================================================
+
+#ifndef CLBLAST_ROUTINES_XIM2COL_H_
+#define CLBLAST_ROUTINES_XIM2COL_H_
+
+#include "routine.hpp"
+
+namespace clblast {
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class Xim2col: public Routine {
+ public:
+
+  // Constructor
+  Xim2col(Queue &queue, EventPointer event, const std::string &name = "IM2COL");
+
+  // Templated-precision implementation of the routine
+  void DoIm2col(const size_t channels, const size_t height, const size_t width,
+                const size_t kernel_h, const size_t kernel_w,
+                const size_t pad_h, const size_t pad_w,
+                const size_t stride_h, const size_t stride_w,
+                const size_t dilation_h, const size_t dilation_w,
+                const Buffer<T> &im_buffer, const size_t im_offset,
+                const Buffer<T> &col_buffer, const size_t col_offset);
+};
+
+// =================================================================================================
+} // namespace clblast
+
+// CLBLAST_ROUTINES_XIM2COL_H_
+#endif

--- a/src/utilities/utilities.hpp
+++ b/src/utilities/utilities.hpp
@@ -171,10 +171,10 @@ struct Arguments {
   size_t channels = 1;
   size_t height = 1;
   size_t width = 1;
-  size_t kernel_h = 1;
-  size_t kernel_w = 1;
-  size_t pad_h = 1;
-  size_t pad_w = 1;
+  size_t kernel_h = 3;
+  size_t kernel_w = 3;
+  size_t pad_h = 0;
+  size_t pad_w = 0;
   size_t stride_h = 1;
   size_t stride_w = 1;
   size_t dilation_h = 1;

--- a/src/utilities/utilities.hpp
+++ b/src/utilities/utilities.hpp
@@ -78,6 +78,19 @@ constexpr auto kArgAlpha = "alpha";
 constexpr auto kArgBeta = "beta";
 constexpr auto kArgBatchCount = "batch_num";
 
+// Constants for im2col
+constexpr auto kArgChannels = "channels";
+constexpr auto kArgHeight = "height";
+constexpr auto kArgWidth = "width";
+constexpr auto kArgKernelH = "kernelh";
+constexpr auto kArgKernelW = "kernelw";
+constexpr auto kArgPadH = "padh";
+constexpr auto kArgPadW = "padw";
+constexpr auto kArgStrideH = "strideh";
+constexpr auto kArgStrideW = "stridew";
+constexpr auto kArgDilationH = "dilationh";
+constexpr auto kArgDilationW = "dilationw";
+
 // The tuner-specific arguments in string form
 constexpr auto kArgFraction = "fraction";
 
@@ -170,6 +183,18 @@ struct Arguments {
   size_t imax_offset = 0;
   T alpha = ConstantOne<T>();
   T beta = ConstantOne<T>();
+  // Arguments for im2col
+  size_t channels = 1;
+  size_t height = 1;
+  size_t width = 1;
+  size_t kernel_h = 1;
+  size_t kernel_w = 1;
+  size_t pad_h = 1;
+  size_t pad_w = 1;
+  size_t stride_h = 1;
+  size_t stride_w = 1;
+  size_t dilation_h = 1;
+  size_t dilation_w = 1;
   // Batch-specific arguments
   size_t batch_count = 1;
   std::vector<size_t> x_offsets; // = {0};

--- a/test/correctness/routines/levelx/xim2col.cpp
+++ b/test/correctness/routines/levelx/xim2col.cpp
@@ -1,0 +1,26 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// =================================================================================================
+
+#include "test/correctness/testblas.hpp"
+#include "test/routines/levelx/xim2col.hpp"
+
+// Main function (not within the clblast namespace)
+int main(int argc, char *argv[]) {
+  auto errors = size_t{0};
+  errors += clblast::RunTests<clblast::TestXim2col<float>, float, float>(argc, argv, false, "SIM2COL");
+  errors += clblast::RunTests<clblast::TestXim2col<double>, double, double>(argc, argv, true, "DIM2COL");
+  errors += clblast::RunTests<clblast::TestXim2col<clblast::float2>, clblast::float2, clblast::float2>(argc, argv, true, "CIM2COL");
+  errors += clblast::RunTests<clblast::TestXim2col<clblast::double2>, clblast::double2, clblast::double2>(argc, argv, true, "ZIM2COL");
+  errors += clblast::RunTests<clblast::TestXim2col<clblast::half>, clblast::half, clblast::half>(argc, argv, true, "HIM2COL");
+  if (errors > 0) { return 1; } else { return 0; }
+}
+
+// =================================================================================================

--- a/test/correctness/testblas.hpp
+++ b/test/correctness/testblas.hpp
@@ -56,6 +56,8 @@ class TestBlas: public Tester<T,U> {
   static const std::vector<size_t> kMatrixDims;
   static const std::vector<size_t> kMatrixVectorDims;
   static const std::vector<size_t> kBandSizes;
+  static const std::vector<size_t> kPadSizes;
+  static const std::vector<size_t> kKernelSizes;
   static const std::vector<size_t> kBatchCounts;
   const std::vector<size_t> kOffsets;
   const std::vector<U> kAlphaValues;
@@ -130,6 +132,8 @@ template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kMatr
 template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kMatrixVectorDims = { 61, 256 };
 template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kBandSizes = { 4, 19 };
 template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kBatchCounts = { 1, 3 };
+template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kPadSizes = { 0 };
+template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kKernelSizes = { 1, 3 };
 
 // Test settings for the invalid tests
 template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kInvalidIncrements = { 0, 1 };
@@ -223,6 +227,17 @@ size_t RunTests(int argc, char *argv[], const bool silent, const std::string &na
   auto imax_offsets = std::vector<size_t>{args.imax_offset};
   auto alphas = std::vector<U>{args.alpha};
   auto betas = std::vector<U>{args.beta};
+  auto channelss = std::vector<size_t>{args.channels};
+  auto heights = std::vector<size_t>{args.height};
+  auto widths = std::vector<size_t>{args.width};
+  auto kernel_hs = std::vector<size_t>{args.kernel_h};
+  auto kernel_ws = std::vector<size_t>{args.kernel_w};
+  auto pad_hs = std::vector<size_t>{args.pad_h};
+  auto pad_ws = std::vector<size_t>{args.pad_w};
+  auto stride_hs = std::vector<size_t>{args.stride_h};
+  auto stride_ws = std::vector<size_t>{args.stride_w};
+  auto dilation_hs = std::vector<size_t>{args.dilation_h};
+  auto dilation_ws = std::vector<size_t>{args.dilation_w};
   auto batch_counts = std::vector<size_t>{args.batch_count};
   auto x_sizes = std::vector<size_t>{args.x_size};
   auto y_sizes = std::vector<size_t>{args.y_size};
@@ -267,6 +282,17 @@ size_t RunTests(int argc, char *argv[], const bool silent, const std::string &na
     if (option == kArgImaxOffset) { imax_offsets = tester.kOffsets; }
     if (option == kArgAlpha) { alphas = tester.kAlphaValues; }
     if (option == kArgBeta) { betas = tester.kBetaValues; }
+    if (option == kArgChannels) { channelss = tester.kMatrixDims; }
+    if (option == kArgHeight) { heights = tester.kMatrixDims; }
+    if (option == kArgWidth) { widths = tester.kMatrixDims; }
+    if (option == kArgKernelH) { kernel_hs = tester.kKernelSizes; }
+    if (option == kArgKernelW) { kernel_ws = tester.kKernelSizes; }
+    if (option == kArgPadH) { pad_hs = tester.kPadSizes; }
+    if (option == kArgPadW) { pad_ws = tester.kPadSizes; }
+    if (option == kArgStrideH) { stride_hs = tester.kKernelSizes; }
+    if (option == kArgStrideW) { stride_ws = tester.kKernelSizes; }
+    if (option == kArgDilationH) { dilation_hs = tester.kKernelSizes; }
+    if (option == kArgDilationW) { dilation_ws = tester.kKernelSizes; }
     if (option == kArgBatchCount) { batch_counts = tester.kBatchCounts; }
 
     if (option == kArgXOffset) { x_sizes = tester.kVecSizes; }
@@ -310,9 +336,31 @@ size_t RunTests(int argc, char *argv[], const bool silent, const std::string &na
                                                     for (auto &imax_offset: imax_offsets) { r_args.imax_offset = imax_offset;
                                                       for (auto &alpha: alphas) { r_args.alpha = alpha;
                                                         for (auto &beta: betas) { r_args.beta = beta;
-                                                          for (auto &batch_count: batch_counts) { r_args.batch_count = batch_count;
-                                                            C::SetSizes(r_args);
-                                                            regular_test_vector.push_back(r_args);
+                                                          for (auto &channels: channelss) { r_args.channels = channels;
+                                                            for (auto &height: heights) { r_args.height = height;
+                                                              for (auto &width: widths) { r_args.width = width;
+                                                                for (auto &kernel_h: kernel_hs) { r_args.kernel_h = kernel_h;
+                                                                  for (auto &kernel_w: kernel_ws) { r_args.kernel_w = kernel_w;
+                                                                    for (auto &pad_h: pad_hs) { r_args.pad_h = pad_h;
+                                                                      for (auto &pad_w: pad_ws) { r_args.pad_w = pad_w;
+                                                                        for (auto &stride_h: stride_hs) { r_args.stride_h = stride_h;
+                                                                          for (auto &stride_w: stride_ws) { r_args.stride_w = stride_w;
+                                                                            for (auto &dilation_h: dilation_hs) { r_args.dilation_h = dilation_h;
+                                                                              for (auto &dilation_w: dilation_ws) { r_args.dilation_w = dilation_w;
+                                                                                for (auto &batch_count: batch_counts) { r_args.batch_count = batch_count;
+                                                                                  C::SetSizes(r_args);
+                                                                                  regular_test_vector.push_back(r_args);
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
                                                           }
                                                         }
                                                       }

--- a/test/correctness/testblas.hpp
+++ b/test/correctness/testblas.hpp
@@ -57,6 +57,7 @@ class TestBlas: public Tester<T,U> {
   static const std::vector<size_t> kMatrixVectorDims;
   static const std::vector<size_t> kBandSizes;
   static const std::vector<size_t> kPadSizes;
+  static const std::vector<size_t> kDilationSizes;
   static const std::vector<size_t> kKernelSizes;
   static const std::vector<size_t> kBatchCounts;
   const std::vector<size_t> kOffsets;
@@ -132,7 +133,8 @@ template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kMatr
 template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kMatrixVectorDims = { 61, 256 };
 template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kBandSizes = { 4, 19 };
 template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kBatchCounts = { 1, 3 };
-template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kPadSizes = { 0 };
+template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kPadSizes = { 0, 1 };
+template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kDilationSizes = { 1, 2 };
 template <typename T, typename U> const std::vector<size_t> TestBlas<T,U>::kKernelSizes = { 1, 3 };
 
 // Test settings for the invalid tests
@@ -282,7 +284,7 @@ size_t RunTests(int argc, char *argv[], const bool silent, const std::string &na
     if (option == kArgImaxOffset) { imax_offsets = tester.kOffsets; }
     if (option == kArgAlpha) { alphas = tester.kAlphaValues; }
     if (option == kArgBeta) { betas = tester.kBetaValues; }
-    if (option == kArgChannels) { channelss = tester.kMatrixDims; }
+    if (option == kArgChannels) { channelss = tester.kKernelSizes; }
     if (option == kArgHeight) { heights = tester.kMatrixDims; }
     if (option == kArgWidth) { widths = tester.kMatrixDims; }
     if (option == kArgKernelH) { kernel_hs = tester.kKernelSizes; }
@@ -291,8 +293,8 @@ size_t RunTests(int argc, char *argv[], const bool silent, const std::string &na
     if (option == kArgPadW) { pad_ws = tester.kPadSizes; }
     if (option == kArgStrideH) { stride_hs = tester.kKernelSizes; }
     if (option == kArgStrideW) { stride_ws = tester.kKernelSizes; }
-    if (option == kArgDilationH) { dilation_hs = tester.kKernelSizes; }
-    if (option == kArgDilationW) { dilation_ws = tester.kKernelSizes; }
+    if (option == kArgDilationH) { dilation_hs = tester.kDilationSizes; }
+    if (option == kArgDilationW) { dilation_ws = tester.kDilationSizes; }
     if (option == kArgBatchCount) { batch_counts = tester.kBatchCounts; }
 
     if (option == kArgXOffset) { x_sizes = tester.kVecSizes; }

--- a/test/correctness/tester.cpp
+++ b/test/correctness/tester.cpp
@@ -371,6 +371,12 @@ std::string Tester<T,U>::GetOptionsString(const Arguments<U> &args) {
     if (o == kArgWidth)    { result += kArgWidth + equals + ToString(args.width) + " "; }
     if (o == kArgKernelH)  { result += kArgKernelH + equals + ToString(args.kernel_h) + " "; }
     if (o == kArgKernelW)  { result += kArgKernelW + equals + ToString(args.kernel_w) + " "; }
+    if (o == kArgPadH)     { result += kArgPadH + equals + ToString(args.pad_h) + " "; }
+    if (o == kArgPadW)     { result += kArgPadW + equals + ToString(args.pad_w) + " "; }
+    if (o == kArgStrideH)  { result += kArgStrideH + equals + ToString(args.stride_h) + " "; }
+    if (o == kArgStrideW)  { result += kArgStrideW + equals + ToString(args.stride_w) + " "; }
+    if (o == kArgDilationH){ result += kArgDilationH + equals + ToString(args.dilation_h) + " "; }
+    if (o == kArgDilationW){ result += kArgDilationW + equals + ToString(args.dilation_w) + " "; }
   }
   return result;
 }

--- a/test/correctness/tester.cpp
+++ b/test/correctness/tester.cpp
@@ -366,6 +366,11 @@ std::string Tester<T,U>::GetOptionsString(const Arguments<U> &args) {
     if (o == kArgAlpha)    { result += kArgAlpha + equals + ToString(args.alpha) + " "; }
     if (o == kArgBeta)     { result += kArgBeta + equals + ToString(args.beta) + " "; }
     if (o == kArgBatchCount){result += kArgBatchCount + equals + ToString(args.batch_count) + " "; }
+    if (o == kArgChannels) { result += kArgChannels + equals + ToString(args.channels) + " "; }
+    if (o == kArgHeight)   { result += kArgHeight + equals + ToString(args.height) + " "; }
+    if (o == kArgWidth)    { result += kArgWidth + equals + ToString(args.width) + " "; }
+    if (o == kArgKernelH)  { result += kArgKernelH + equals + ToString(args.kernel_h) + " "; }
+    if (o == kArgKernelW)  { result += kArgKernelW + equals + ToString(args.kernel_w) + " "; }
   }
   return result;
 }

--- a/test/performance/client.cpp
+++ b/test/performance/client.cpp
@@ -93,7 +93,7 @@ Arguments<U> Client<T,U>::ParseArguments(int argc, char *argv[], const size_t le
     if (o == kArgAPOffset) { args.ap_offset= GetArgument(command_line_args, help, kArgAPOffset, size_t{0}); }
 
     // Scalar result arguments
-    if (o == kArgDotOffset)  { args.dot_offset = GetArgument(command_line_args, help, kArgDotOffset, size_t{0}); }
+    if (o == kArgDotOffset)   { args.dot_offset = GetArgument(command_line_args, help, kArgDotOffset, size_t{0}); }
     if (o == kArgNrm2Offset)  { args.nrm2_offset = GetArgument(command_line_args, help, kArgNrm2Offset, size_t{0}); }
     if (o == kArgAsumOffset)  { args.asum_offset = GetArgument(command_line_args, help, kArgAsumOffset, size_t{0}); }
     if (o == kArgImaxOffset)  { args.imax_offset = GetArgument(command_line_args, help, kArgImaxOffset, size_t{0}); }
@@ -104,6 +104,19 @@ Arguments<U> Client<T,U>::ParseArguments(int argc, char *argv[], const size_t le
     // Scalar values 
     if (o == kArgAlpha) { args.alpha = GetArgument(command_line_args, help, kArgAlpha, GetScalar<U>()); }
     if (o == kArgBeta)  { args.beta  = GetArgument(command_line_args, help, kArgBeta, GetScalar<U>()); }
+
+    // Arguments for im2col
+    if (o == kArgChannels)  { args.channels = GetArgument(command_line_args, help, kArgChannels, size_t{64}); }
+    if (o == kArgHeight)    { args.height = GetArgument(command_line_args, help, kArgHeight, size_t{64}); }
+    if (o == kArgWidth)     { args.width = GetArgument(command_line_args, help, kArgWidth, size_t{64}); }
+    if (o == kArgKernelH)   { args.kernel_h = GetArgument(command_line_args, help, kArgKernelH, size_t{3}); }
+    if (o == kArgKernelW)   { args.kernel_w = GetArgument(command_line_args, help, kArgKernelW, size_t{3}); }
+    if (o == kArgPadH)      { args.pad_h = GetArgument(command_line_args, help, kArgPadH, size_t{0}); }
+    if (o == kArgPadW)      { args.pad_w = GetArgument(command_line_args, help, kArgPadW, size_t{0}); }
+    if (o == kArgStrideH)   { args.stride_h = GetArgument(command_line_args, help, kArgStrideH, size_t{1}); }
+    if (o == kArgStrideW)   { args.stride_w = GetArgument(command_line_args, help, kArgStrideW, size_t{1}); }
+    if (o == kArgDilationH) { args.dilation_h = GetArgument(command_line_args, help, kArgDilationH, size_t{1}); }
+    if (o == kArgDilationW) { args.dilation_w = GetArgument(command_line_args, help, kArgDilationW, size_t{1}); }
   }
 
   // These are the options common to all routines
@@ -379,6 +392,17 @@ void Client<T,U>::PrintTableRow(const Arguments<U>& args,
     else if (o == kArgAsumOffset){integers.push_back(args.asum_offset); }
     else if (o == kArgImaxOffset){integers.push_back(args.imax_offset); }
     else if (o == kArgBatchCount){integers.push_back(args.batch_count); }
+    else if (o == kArgChannels)  {integers.push_back(args.channels); }
+    else if (o == kArgHeight)    {integers.push_back(args.height); }
+    else if (o == kArgWidth)     {integers.push_back(args.width); }
+    else if (o == kArgKernelH)   {integers.push_back(args.kernel_h); }
+    else if (o == kArgKernelW)   {integers.push_back(args.kernel_w); }
+    else if (o == kArgPadH)      {integers.push_back(args.pad_h); }
+    else if (o == kArgPadW)      {integers.push_back(args.pad_w); }
+    else if (o == kArgStrideH)   {integers.push_back(args.stride_h); }
+    else if (o == kArgStrideW)   {integers.push_back(args.stride_w); }
+    else if (o == kArgDilationH) {integers.push_back(args.dilation_h); }
+    else if (o == kArgDilationW) {integers.push_back(args.dilation_w); }
   }
   auto strings = std::vector<std::string>{};
   for (auto &o: options_) {

--- a/test/performance/routines/levelx/xim2col.cpp
+++ b/test/performance/routines/levelx/xim2col.cpp
@@ -1,0 +1,33 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// =================================================================================================
+
+#include "test/performance/client.hpp"
+#include "test/routines/levelx/xim2col.hpp"
+
+// Main function (not within the clblast namespace)
+int main(int argc, char *argv[]) {
+  const auto command_line_args = clblast::RetrieveCommandLineArguments(argc, argv);
+  switch(clblast::GetPrecision(command_line_args, clblast::Precision::kSingle)) {
+    case clblast::Precision::kHalf:
+      clblast::RunClient<clblast::TestXim2col<clblast::half>, clblast::half, clblast::half>(argc, argv); break;
+    case clblast::Precision::kSingle:
+      clblast::RunClient<clblast::TestXim2col<float>, float, float>(argc, argv); break;
+    case clblast::Precision::kDouble:
+      clblast::RunClient<clblast::TestXim2col<double>, double, double>(argc, argv); break;
+    case clblast::Precision::kComplexSingle:
+      clblast::RunClient<clblast::TestXim2col<clblast::float2>, clblast::float2, clblast::float2>(argc, argv); break;
+    case clblast::Precision::kComplexDouble:
+      clblast::RunClient<clblast::TestXim2col<clblast::double2>, clblast::double2, clblast::double2>(argc, argv); break;
+  }
+  return 0;
+}
+
+// =================================================================================================

--- a/test/routines/levelx/xim2col.hpp
+++ b/test/routines/levelx/xim2col.hpp
@@ -1,0 +1,165 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements a class with static methods to describe the Xim2col routine. Examples of
+// such 'descriptions' are how to calculate the size a of buffer or how to run the routine. These
+// static methods are used by the correctness tester and the performance tester.
+//
+// =================================================================================================
+
+#ifndef CLBLAST_TEST_ROUTINES_XIM2COL_H_
+#define CLBLAST_TEST_ROUTINES_XIM2COL_H_
+
+#include "test/routines/common.hpp"
+
+namespace clblast {
+// =================================================================================================
+
+template <typename T>
+StatusCode RunReference(const Arguments<T> &args, BuffersHost<T> &buffers_host) {
+  for (auto c_id = size_t{0}; c_id < args.channels; ++c_id) { // input channels
+    for (auto kh_id = size_t{0}; kh_id < args.kernel_h; ++kh_id) { // kernel height
+      for (auto kw_id = size_t{0}; kw_id < args.kernel_w; ++kw_id) { // kernel width
+        for (auto h_id = size_t{0}; h_id < args.height; h_id += args.stride_h) { // image height
+          for (auto w_id = size_t{0}; w_id < args.width; w_id += args.stride_w) { // image width
+
+            // Retrieves the input value
+            const auto h_index = -args.pad_h + kh_id * args.dilation_h + h_id;
+            const auto w_index = -args.pad_w + kw_id * args.dilation_w + w_id;
+            auto val = ConstantZero<T>();
+            if (h_index < args.height && w_index < args.width) {
+              const auto input_index = w_index + args.width * (h_index + args.height * c_id);
+              val = buffers_host.a_mat[input_index + args.a_offset];
+            }
+
+            // Sets the output value
+            const auto kernel_index = kw_id + args.kernel_w * kh_id;
+            const auto patch_index = w_id + ((args.width / args.stride_w) * h_id + (args.height / args.stride_h) * c_id);
+            const auto output_index = kernel_index + args.kernel_h * args.kernel_w * patch_index;
+            buffers_host.b_mat[output_index + args.b_offset] = val;
+          }
+        }
+      }
+    }
+  }
+  return StatusCode::kSuccess;
+}
+
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class TestXim2col {
+public:
+
+  // The BLAS level: 4 for the extra routines
+  static size_t BLASLevel() { return 4; }
+
+  // The list of arguments relevant for this routine
+  static std::vector<std::string> GetOptions() {
+    return {kArgChannels, kArgHeight, kArgWidth, kArgKernelH, kArgKernelW, kArgPadH, kArgPadW,
+            kArgStrideH, kArgStrideW, kArgDilationH, kArgDilationW,
+            kArgAOffset, kArgBOffset};
+  }
+  static std::vector<std::string> BuffersIn() { return {kBufMatA, kBufMatB}; }
+  static std::vector<std::string> BuffersOut() { return {kBufMatB}; }
+
+  // Describes how to obtain the sizes of the buffers
+  static size_t NumPatches(const Arguments<T> &args) {
+    return (args.width / args.stride_w) * (args.height / args.stride_h) * args.channels;
+  }
+  static size_t GetSizeA(const Arguments<T> &args) {
+    return args.height * args.width * args.channels + args.a_offset;
+  }
+  static size_t GetSizeB(const Arguments<T> &args) {
+    return args.kernel_w * args.kernel_h * NumPatches(args) + args.b_offset;
+  }
+
+  // Describes how to set the sizes of all the buffers
+  static void SetSizes(Arguments<T> &args) {
+    args.a_size = GetSizeA(args);
+    args.b_size = GetSizeB(args);
+  }
+
+  // Describes what the default values of the leading dimensions of the matrices are
+  static size_t DefaultLDA(const Arguments<T> &) { return 1; } // N/A for this routine
+  static size_t DefaultLDB(const Arguments<T> &) { return 1; } // N/A for this routine
+  static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
+
+  // Describes which transpose options are relevant for this routine
+  using Transposes = std::vector<Transpose>;
+  static Transposes GetATransposes(const Transposes &) { return {}; } // N/A for this routine
+  static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine
+
+  // Describes how to prepare the input data
+  static void PrepareData(const Arguments<T>&, Queue&, const int, std::vector<T>&,
+                          std::vector<T>&, std::vector<T>&, std::vector<T>&, std::vector<T>&,
+                          std::vector<T>&, std::vector<T>&) {} // N/A for this routine
+
+  // Describes how to run the CLBlast routine
+  static StatusCode RunRoutine(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
+    auto queue_plain = queue();
+    auto event = cl_event{};
+    auto status = Im2col<T>(args.channels, args.height, args.width,
+                            args.kernel_h, args.kernel_w,
+                            args.pad_h, args.pad_w,
+                            args.stride_h, args.stride_w,
+                            args.dilation_h, args.dilation_w,
+                            buffers.a_mat(), args.a_offset,
+                            buffers.b_mat(), args.b_offset,
+                            &queue_plain, &event);
+    if (status == StatusCode::kSuccess) { clWaitForEvents(1, &event); clReleaseEvent(event); }
+    return status;
+  }
+
+  // Describes how to run a naive version of the routine (for correctness/performance comparison).
+  // Note that a proper clBLAS or CPU BLAS comparison is not available for non-BLAS routines.
+  static StatusCode RunReference1(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
+    auto buffers_host = BuffersHost<T>();
+    DeviceToHost(args, buffers, buffers_host, queue, BuffersIn());
+    const auto status = RunReference(args, buffers_host);
+    HostToDevice(args, buffers, buffers_host, queue, BuffersOut());
+    return status;
+  }
+
+  static StatusCode RunReference2(const Arguments<T> &args, BuffersHost<T> &buffers_host, Queue&) {
+    return RunReference(args, buffers_host);
+  }
+  static StatusCode RunReference3(const Arguments<T> &, BuffersCUDA<T> &, Queue &) {
+    return StatusCode::kUnknownError;
+  }
+
+  // Describes how to download the results of the computation (more importantly: which buffer)
+  static std::vector<T> DownloadResult(const Arguments<T> &args, Buffers<T> &buffers, Queue &queue) {
+    std::vector<T> result(args.b_size, static_cast<T>(0));
+    buffers.b_mat.Read(queue, args.b_size, result);
+    return result;
+  }
+
+  // Describes how to compute the indices of the result buffer
+  static size_t ResultID1(const Arguments<T> &args) { return args.kernel_h * args.kernel_w; }
+  static size_t ResultID2(const Arguments<T> &args) { return NumPatches(args); }
+  static size_t GetResultIndex(const Arguments<T> &args, const size_t id1, const size_t id2) {
+    return id1 + args.kernel_h * args.kernel_w * id2 + args.b_offset;
+  }
+
+  // Describes how to compute performance metrics
+  static size_t GetFlops(const Arguments<T> &args) {
+    return 1;
+  }
+  static size_t GetBytes(const Arguments<T> &args) {
+    return (1) * sizeof(T);
+  }
+};
+
+// =================================================================================================
+} // namespace clblast
+
+// CLBLAST_TEST_ROUTINES_XIM2COL_H_
+#endif

--- a/test/routines/levelx/xim2col.hpp
+++ b/test/routines/levelx/xim2col.hpp
@@ -134,7 +134,9 @@ public:
     return 1;
   }
   static size_t GetBytes(const Arguments<T> &args) {
-    return (1) * sizeof(T);
+    const auto input = args.channels * args.width * args.height; // possibly less with striding
+    const auto output = args.kernel_h * args.kernel_w * NumPatches(args);
+    return (input + output) * sizeof(T);
   }
 };
 

--- a/test/routines/levelx/xomatcopy.hpp
+++ b/test/routines/levelx/xomatcopy.hpp
@@ -114,7 +114,7 @@ class TestXomatcopy {
   static size_t DefaultLDB(const Arguments<T> &args) { return args.m; }
   static size_t DefaultLDC(const Arguments<T> &) { return 1; } // N/A for this routine
 
-  // Describes which omatcopyose options are relevant for this routine
+  // Describes which transpose options are relevant for this routine
   using Transposes = std::vector<Transpose>;
   static Transposes GetATransposes(const Transposes &all) { return all; }
   static Transposes GetBTransposes(const Transposes &) { return {}; } // N/A for this routine


### PR DESCRIPTION
Added simple implementation of the im2col algorithm to be able to express convolutions as GEMM for neural networks. This serves as a stepping stone for other convolution related operations, since the required test infrastructure is now in place..