### PR TITLE
Preparation for size specific parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 
+Development (next version)
+- Kernels are now cached based on their tuning parameters: fits the use-case of 'OverrideParameters'
+
 Version 1.1.0
 - The tuning database now has defaults per architecture (e.g. NVIDIA Kepler SM3.5, AMD Fiji)
 - The tuning database now has a dictionary to translate vendor/device names to a common set

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -124,6 +124,15 @@ std::string Database::GetDefines() const {
   return defines;
 }
 
+// ... or just the values as string
+std::string Database::GetValuesString() const {
+  std::string defines{};
+  for (auto &parameter: *parameters_) {
+    defines += "_"+ToString(parameter.second);
+  }
+  return defines;
+}
+
 // Retrieves the names of all the parameters
 std::vector<std::string> Database::GetParameterNames() const {
   auto parameter_names = std::vector<std::string>();

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -53,7 +53,8 @@ class Database {
   // Obtain a list of OpenCL pre-processor defines based on the parameters
   std::string GetDefines() const;
 
-  // Retrieves the names of all the parameters
+  // Retrieves the values or names of all the parameters
+  std::string GetValuesString() const;
   std::vector<std::string> GetParameterNames() const;
 
  private:

--- a/src/database/database_structure.hpp
+++ b/src/database/database_structure.hpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <array>
 #include <vector>
-#include <unordered_map>
+#include <map>
 
 namespace clblast {
 // A special namespace to hold all the global constant variables (including the database entries)
@@ -29,8 +29,8 @@ namespace database {
 using Name = std::array<char, 51>; // name as stored in database (50 chars + string terminator)
 using Params = std::array<size_t, 14>; // parameters as stored in database
 
-// Type alias after extracting from the database (map for improved code readability)
-using Parameters = std::unordered_map<std::string, size_t>; // parameters after reading from DB
+// Type alias after extracting from the database (sorted map for improved code readability)
+using Parameters = std::map<std::string, size_t>; // parameters after reading from DB
 
 // The OpenCL device types
 const std::string kDeviceTypeCPU = "CPU";

--- a/src/routine.cpp
+++ b/src/routine.cpp
@@ -85,9 +85,16 @@ void Routine::InitDatabase(const std::vector<database::DatabaseEntry> &userDatab
 
 void Routine::InitProgram(std::initializer_list<const char *> source) {
 
+  // Determines the identifier for this particular routine call
+  auto routine_info = routine_name_;
+  for (const auto &kernel_name : kernel_names_) {
+    routine_info += "_" + kernel_name + db_(kernel_name).GetValuesString();
+  }
+  log_debug(routine_info);
+
   // Queries the cache to see whether or not the program (context-specific) is already there
   bool has_program;
-  program_ = ProgramCache::Instance().Get(ProgramKeyRef{ context_(), device_(), precision_, routine_name_ },
+  program_ = ProgramCache::Instance().Get(ProgramKeyRef{ context_(), device_(), precision_, routine_info },
                                           &has_program);
   if (has_program) { return; }
 
@@ -102,12 +109,12 @@ void Routine::InitProgram(std::initializer_list<const char *> source) {
   // is, a program is created and stored in the cache
   const auto device_name = GetDeviceName(device_);
   bool has_binary;
-  auto binary = BinaryCache::Instance().Get(BinaryKeyRef{ precision_, routine_name_, device_name },
+  auto binary = BinaryCache::Instance().Get(BinaryKeyRef{ precision_, routine_info, device_name },
                                             &has_binary);
   if (has_binary) {
     program_ = Program(device_, context_, binary);
     program_.Build(device_, options);
-    ProgramCache::Instance().Store(ProgramKey{ context_(), device_(), precision_, routine_name_ },
+    ProgramCache::Instance().Store(ProgramKey{ context_(), device_(), precision_, routine_info },
                                    Program{ program_ });
     return;
   }
@@ -189,10 +196,10 @@ void Routine::InitProgram(std::initializer_list<const char *> source) {
   }
 
   // Store the compiled binary and program in the cache
-  BinaryCache::Instance().Store(BinaryKey{ precision_, routine_name_, device_name },
+  BinaryCache::Instance().Store(BinaryKey{precision_, routine_info, device_name},
                                 program_.GetIR());
 
-  ProgramCache::Instance().Store(ProgramKey{ context_(), device_(), precision_, routine_name_ },
+  ProgramCache::Instance().Store(ProgramKey{context_(), device_(), precision_, routine_info},
                                  Program{ program_ });
 
   // Prints the elapsed compilation time in case of debugging in verbose mode

--- a/src/routine.cpp
+++ b/src/routine.cpp
@@ -77,6 +77,7 @@ void Routine::InitDatabase(const std::vector<database::DatabaseEntry> &userDatab
     if (has_db) { continue; }
 
     // Builds the parameter database for this device and routine set and stores it in the cache
+    log_debug("Searching database for kernel '" + kernel_name + "'");
     db_(kernel_name) = Database(device_, kernel_name, precision_, userDatabase);
     DatabaseCache::Instance().Store(DatabaseKey{ platform_, device_(), precision_, kernel_name },
                                     Database{ db_(kernel_name) });

--- a/test/correctness/misc/override_parameters.cpp
+++ b/test/correctness/misc/override_parameters.cpp
@@ -37,6 +37,7 @@ size_t RunOverrideTests(int argc, char *argv[], const bool silent, const std::st
   const auto valid_settings = std::vector<std::unordered_map<std::string,size_t>>{
     { {"KWG",16}, {"KWI",2}, {"MDIMA",4}, {"MDIMC",4}, {"MWG",16}, {"NDIMB",4}, {"NDIMC",4}, {"NWG",16}, {"SA",0}, {"SB",0}, {"STRM",0}, {"STRN",0}, {"VWM",1}, {"VWN",1} },
     { {"KWG",32}, {"KWI",2}, {"MDIMA",4}, {"MDIMC",4}, {"MWG",32}, {"NDIMB",4}, {"NDIMC",4}, {"NWG",32}, {"SA",0}, {"SB",0}, {"STRM",0}, {"STRN",0}, {"VWM",1}, {"VWN",1} },
+    { {"KWG",16}, {"KWI",2}, {"MDIMA",4}, {"MDIMC",4}, {"MWG",16}, {"NDIMB",4}, {"NDIMC",4}, {"NWG",16}, {"SA",0}, {"SB",0}, {"STRM",0}, {"STRN",0}, {"VWM",1}, {"VWN",1} },
   };
   const auto invalid_settings = std::vector<std::unordered_map<std::string,size_t>>{
     { {"KWI",2}, {"MDIMA",4}, {"MDIMC",4}, {"MWG",16}, {"NDIMB",4}, {"NDIMC",4}, {"NWG",16}, {"SA",0} },


### PR DESCRIPTION
Kernels are now cached based on their routine name and their tuning parameters. This is useful in the future in case of multiple problem-size-specific tuning results, but already helps for users often using the `OverrideParameters` function: existing kernels will still remain cached and new ones will be added for future use.