### PR TITLE
Cuda API preparation

### DIFF
--- a/src/cache.hpp
+++ b/src/cache.hpp
@@ -80,8 +80,8 @@ extern template std::string BinaryCache::Get(const BinaryKeyRef &, bool *) const
 
 // The key struct for the cache of compiled OpenCL programs (context-dependent)
 // Order of fields: context, device_id, precision, routine_name (smaller fields first)
-typedef std::tuple<cl_context, cl_device_id, Precision, std::string> ProgramKey;
-typedef std::tuple<const cl_context &, const cl_device_id &, const Precision &, const std::string &> ProgramKeyRef;
+typedef std::tuple<RawContext, RawDeviceID, Precision, std::string> ProgramKey;
+typedef std::tuple<const RawContext &, const RawDeviceID &, const Precision &, const std::string &> ProgramKeyRef;
 
 typedef Cache<ProgramKey, Program> ProgramCache;
 
@@ -94,8 +94,8 @@ class Database;
 
 // The key struct for the cache of database maps.
 // Order of fields: platform_id, device_id, precision, kernel_name (smaller fields first)
-typedef std::tuple<cl_platform_id, cl_device_id, Precision, std::string> DatabaseKey;
-typedef std::tuple<const cl_platform_id &, const cl_device_id &, const Precision &, const std::string &> DatabaseKeyRef;
+typedef std::tuple<RawPlatformID, RawDeviceID, Precision, std::string> DatabaseKey;
+typedef std::tuple<const RawPlatformID &, const RawDeviceID &, const Precision &, const std::string &> DatabaseKeyRef;
 
 typedef Cache<DatabaseKey, Database> DatabaseCache;
 

--- a/src/clblast.cpp
+++ b/src/clblast.cpp
@@ -2492,7 +2492,7 @@ StatusCode OverrideParameters(const cl_device_id device, const std::string &kern
 
     // Retrieves the device name
     const auto device_cpp = Device(device);
-    const auto platform_id = device_cpp.Platform();
+    const auto platform_id = device_cpp.PlatformID();
     const auto device_name = GetDeviceName(device_cpp);
 
     // Retrieves the current database values to verify whether the new ones are complete

--- a/src/routine.cpp
+++ b/src/routine.cpp
@@ -60,7 +60,7 @@ Routine::Routine(Queue &queue, EventPointer event, const std::string &name,
     event_(event),
     context_(queue_.GetContext()),
     device_(queue_.GetDevice()),
-    platform_(device_.Platform()),
+    platform_(device_.PlatformID()),
     db_(kernel_names) {
 
   InitDatabase(userDatabase);
@@ -188,7 +188,7 @@ void Routine::InitProgram(std::initializer_list<const char *> source) {
   program_ = Program(context_, source_string);
   try {
     program_.Build(device_, options);
-  } catch (const CLError &e) {
+  } catch (const CLCudaAPIError &e) {
     if (e.status() == CL_BUILD_PROGRAM_FAILURE) {
       fprintf(stdout, "OpenCL compiler error/warning: %s\n",
               program_.GetBuildInfo(device_).c_str());

--- a/src/routine.hpp
+++ b/src/routine.hpp
@@ -75,7 +75,6 @@ class Routine {
   EventPointer event_;
   const Context context_;
   const Device device_;
-  const cl_platform_id platform_;
 
   // Compiled program (either retrieved from cache or compiled in slow path)
   Program program_;

--- a/src/utilities/clblast_exceptions.cpp
+++ b/src/utilities/clblast_exceptions.cpp
@@ -55,7 +55,7 @@ StatusCode DispatchException()
   } catch (BLASError &e) {
     // no message is printed for invalid argument errors
     status = e.status();
-  } catch (CLError &e) {
+  } catch (CLCudaAPIError &e) {
     message = e.what();
     status = static_cast<StatusCode>(e.status());
   } catch (RuntimeErrorCode &e) {

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -391,16 +391,9 @@ template <> Precision PrecisionValue<double2>() { return Precision::kComplexDoub
 // Returns false is this precision is not supported by the device
 template <> bool PrecisionSupported<float>(const Device &) { return true; }
 template <> bool PrecisionSupported<float2>(const Device &) { return true; }
-template <> bool PrecisionSupported<double>(const Device &device) {
-  return device.HasExtension(kKhronosDoublePrecision);
-}
-template <> bool PrecisionSupported<double2>(const Device &device) {
-  return device.HasExtension(kKhronosDoublePrecision);
-}
-template <> bool PrecisionSupported<half>(const Device &device) {
-  if (device.Name() == "Mali-T628") { return true; } // supports fp16 but not cl_khr_fp16 officially
-  return device.HasExtension(kKhronosHalfPrecision);
-}
+template <> bool PrecisionSupported<double>(const Device &device) { return device.SupportsFP64(); }
+template <> bool PrecisionSupported<double2>(const Device &device) { return device.SupportsFP64(); }
+template <> bool PrecisionSupported<half>(const Device &device) { return device.SupportsFP16(); }
 
 // =================================================================================================
 

--- a/src/utilities/utilities.hpp
+++ b/src/utilities/utilities.hpp
@@ -31,15 +31,13 @@ namespace clblast {
 // =================================================================================================
 
 // Shorthands for half-precision
-using half = cl_half; // based on the OpenCL type, which is actually an 'unsigned short'
+using half = unsigned short; // the 'cl_half' OpenCL type is actually an 'unsigned short'
 
 // Shorthands for complex data-types
 using float2 = std::complex<float>;
 using double2 = std::complex<double>;
 
 // Khronos OpenCL extensions
-const std::string kKhronosHalfPrecision = "cl_khr_fp16";
-const std::string kKhronosDoublePrecision = "cl_khr_fp64";
 const std::string kKhronosAttributesAMD = "cl_amd_device_attribute_query";
 const std::string kKhronosAttributesNVIDIA = "cl_nv_device_attribute_query";
 

--- a/test/diagnostics.cpp
+++ b/test/diagnostics.cpp
@@ -85,7 +85,7 @@ void OpenCLDiagnostics(int argc, char *argv[]) {
   printf("* device.Name()                 %.4lf ms\n", TimeFunction(kNumRuns, [&](){device.Name();} ));
   printf("* device.Vendor()               %.4lf ms\n", TimeFunction(kNumRuns, [&](){device.Vendor();} ));
   printf("* device.Version()              %.4lf ms\n", TimeFunction(kNumRuns, [&](){device.Version();} ));
-  printf("* device.Platform()             %.4lf ms\n", TimeFunction(kNumRuns, [&](){device.Platform();} ));
+  printf("* device.Platform()             %.4lf ms\n", TimeFunction(kNumRuns, [&](){ device.PlatformID();} ));
   printf("* Buffer<float>(context, 1024)  %.4lf ms\n", TimeFunction(kNumRuns, [&](){Buffer<float>(context, 1024);} ));
 
   printf("\n");

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -88,7 +88,7 @@ void FloatToHalfBuffer(std::vector<half>& result, const std::vector<float>& sour
 }
 
 // As above, but now for OpenCL data-types instead of std::vectors
-Buffer<float> HalfToFloatBuffer(const Buffer<half>& source, cl_command_queue queue_raw) {
+Buffer<float> HalfToFloatBuffer(const Buffer<half>& source, RawCommandQueue queue_raw) {
   const auto size = source.GetSize() / sizeof(half);
   auto queue = Queue(queue_raw);
   auto context = queue.GetContext();
@@ -99,7 +99,7 @@ Buffer<float> HalfToFloatBuffer(const Buffer<half>& source, cl_command_queue que
   result.Write(queue, size, result_cpu);
   return result;
 }
-void FloatToHalfBuffer(Buffer<half>& result, const Buffer<float>& source, cl_command_queue queue_raw) {
+void FloatToHalfBuffer(Buffer<half>& result, const Buffer<float>& source, RawCommandQueue queue_raw) {
   const auto size = source.GetSize() / sizeof(float);
   auto queue = Queue(queue_raw);
   auto context = queue.GetContext();

--- a/test/test_utilities.hpp
+++ b/test/test_utilities.hpp
@@ -89,8 +89,8 @@ std::vector<float> HalfToFloatBuffer(const std::vector<half>& source);
 void FloatToHalfBuffer(std::vector<half>& result, const std::vector<float>& source);
 
 // As above, but now for OpenCL data-types instead of std::vectors
-Buffer<float> HalfToFloatBuffer(const Buffer<half>& source, cl_command_queue queue_raw);
-void FloatToHalfBuffer(Buffer<half>& result, const Buffer<float>& source, cl_command_queue queue_raw);
+Buffer<float> HalfToFloatBuffer(const Buffer<half>& source, RawCommandQueue queue_raw);
+void FloatToHalfBuffer(Buffer<half>& result, const Buffer<float>& source, RawCommandQueue queue_raw);
 
 // =================================================================================================
 } // namespace clblast


### PR DESCRIPTION
Some preparations for a possible extension to add a CUDA API to CLBlast. This PR moves some OpenCL-specific things to `clpp11.h`, where they should have been in the first place. This updates `clpp11.h` also to version 9.0, to be in sync with [the latest `cupp11.h`](https://github.com/CNugteren/CLCudaAPI/blob/master/include/cupp11.h).