### PR TITLE
Use GNUInstallDirs to determine install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,27 +307,28 @@ if(MSVC)
 endif()
 
 # Installs the library
-install(TARGETS clblast EXPORT CLBlast DESTINATION lib)
-install(FILES include/clblast_half.h DESTINATION include)
+include(GNUInstallDirs)
+
+install(TARGETS clblast EXPORT CLBlast DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES include/clblast_half.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 if(OPENCL)
-  install(FILES include/clblast.h DESTINATION include)
-  install(FILES include/clblast_c.h DESTINATION include)
+  install(FILES include/clblast.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(FILES include/clblast_c.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   if(NETLIB)
-    install(FILES include/clblast_netlib_c.h DESTINATION include)
+    install(FILES include/clblast_netlib_c.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   endif()
 elseif(CUDA)
-  install(FILES include/clblast_cuda.h DESTINATION include)
+  install(FILES include/clblast_cuda.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
 # Installs the config for find_package in dependent projects
-install(EXPORT CLBlast DESTINATION lib/cmake/CLBLast FILE CLBlastConfig.cmake)
+install(EXPORT CLBlast DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CLBLast FILE CLBlastConfig.cmake)
 
 # Install pkg-config file on Linux
 if(UNIX)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/clblast.pc.in"
                    "${CMAKE_CURRENT_BINARY_DIR}/clblast.pc" @ONLY IMMEDIATE)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/clblast.pc
-            DESTINATION lib/pkgconfig)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/clblast.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 # ==================================================================================================

--- a/clblast.pc.in
+++ b/clblast.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: CLBlast
 Description: CLBlast is a modern, lightweight, performant and tunable OpenCL BLAS library written in C++11


### PR DESCRIPTION
The GNUInstallDirs module [1] provides variables that match the install directories for GNU Software and allows users to override them. Without hardcoding paths packagers can choose library paths according to distribution policies (i.e. lib, lib64, lib<arch>, ...).

[1] https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html