### PR TITLE
Override params in clients from tuner JSON

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 
 Development (next version)
 - Re-designed and integrated the auto-tuner, no more dependency on CLTune
+- Made it possible to override the tuning parameters in the clients straight from JSON tuning files
 - Added tuned parameters for various devices (see README)
 
 Version 1.2.0

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -108,6 +108,7 @@ std::string ToString(double value) {
   result << std::fixed << std::setprecision(2) << value;
   return result.str();
 }
+template <> std::string ToString<std::string>(std::string value) { return value; }
 
 // If not possible directly: special cases for complex data-types
 template <>
@@ -273,6 +274,7 @@ template float GetArgument<float>(const std::vector<std::string>&, std::string&,
 template double GetArgument<double>(const std::vector<std::string>&, std::string&, const std::string&, const double);
 template float2 GetArgument<float2>(const std::vector<std::string>&, std::string&, const std::string&, const float2);
 template double2 GetArgument<double2>(const std::vector<std::string>&, std::string&, const std::string&, const double2);
+template std::string GetArgument<std::string>(const std::vector<std::string>&, std::string&, const std::string&, const std::string);
 template Layout GetArgument<Layout>(const std::vector<std::string>&, std::string&, const std::string&, const Layout);
 template Transpose GetArgument<Transpose>(const std::vector<std::string>&, std::string&, const std::string&, const Transpose);
 template Side GetArgument<Side>(const std::vector<std::string>&, std::string&, const std::string&, const Side);

--- a/src/utilities/utilities.hpp
+++ b/src/utilities/utilities.hpp
@@ -236,6 +236,7 @@ struct Arguments {
   size_t step = 1;
   size_t num_steps = 0;
   size_t num_runs = 10;
+  std::vector<std::string> tuner_files = {};
   #ifdef CLBLAST_REF_CUBLAS
     void* cublas_handle; // cublasHandle_t
   #endif

--- a/test/performance/client.cpp
+++ b/test/performance/client.cpp
@@ -146,6 +146,13 @@ Arguments<U> Client<T,U>::ParseArguments(int argc, char *argv[], const size_t le
   args.no_abbrv       = CheckArgument(command_line_args, help, kArgNoAbbreviations);
   warm_up_            = CheckArgument(command_line_args, help, kArgWarmUp);
 
+  // Parse the optional JSON file name arguments
+  const auto tuner_files_default = std::string{"<none>"};
+  const auto tuner_files_string = GetArgument(command_line_args, help, kArgTunerFiles, tuner_files_default);
+  if (tuner_files_string != tuner_files_default) {
+    args.tuner_files = split(tuner_files_string, ',');
+  }
+
   // Prints the chosen (or defaulted) arguments to screen. This also serves as the help message,
   // which is thus always displayed (unless silence is specified).
   if (!args.silent) { fprintf(stdout, "%s\n", help.c_str()); }
@@ -196,8 +203,8 @@ void Client<T,U>::PerformanceTest(Arguments<U> &args, const SetMetric set_sizes)
     if (args.compare_cublas) { cublasSetup(args); }
   #endif
 
-  // Optionally overrides parameters if "CLBLAST_JSON_FILE_OVERRIDE" environmental variable is set
-  OverrideParametersFromJSONFiles(device(), args.precision);
+  // Optionally overrides parameters if tuner files are given (semicolon separated)
+  OverrideParametersFromJSONFiles(args.tuner_files, device(), args.precision);
 
   // Prints the header of the output table
   PrintTableHeader(args);

--- a/test/performance/client.cpp
+++ b/test/performance/client.cpp
@@ -184,9 +184,6 @@ Arguments<U> Client<T,U>::ParseArguments(int argc, char *argv[], const size_t le
 template <typename T, typename U>
 void Client<T,U>::PerformanceTest(Arguments<U> &args, const SetMetric set_sizes) {
 
-  // Prints the header of the output table
-  PrintTableHeader(args);
-
   // Initializes OpenCL and the libraries
   auto platform = Platform(args.platform_id);
   auto device = Device(platform, args.device_id);
@@ -198,6 +195,12 @@ void Client<T,U>::PerformanceTest(Arguments<U> &args, const SetMetric set_sizes)
   #ifdef CLBLAST_REF_CUBLAS
     if (args.compare_cublas) { cublasSetup(args); }
   #endif
+
+  // Optionally overrides parameters if "CLBLAST_JSON_FILE_OVERRIDE" environmental variable is set
+  OverrideParametersFromJSONFiles(device(), args.precision);
+
+  // Prints the header of the output table
+  PrintTableHeader(args);
 
   // Iterates over all "num_step" values jumping by "step" each time
   auto s = size_t{0};

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -122,7 +122,7 @@ void OverrideParametersFromJSONFiles(const std::vector<std::string>& file_names,
   // Retrieves the best parameters for each file from disk
   BestParametersCollection all_parameters = {};
   for (const auto json_file_name : file_names) {
-    GetBestParametersFromJSONFile(json_file_name, all_parameters);
+    GetBestParametersFromJSONFile(json_file_name, all_parameters, precision);
   }
 
   // Applies the parameter override
@@ -145,7 +145,8 @@ void OverrideParametersFromJSONFiles(const std::vector<std::string>& file_names,
 }
 
 void GetBestParametersFromJSONFile(const std::string& file_name,
-                                   BestParametersCollection& all_parameters) {
+                                   BestParametersCollection& all_parameters,
+                                   const Precision precision) {
 
   std::ifstream json_file(file_name);
   if (!json_file) {
@@ -191,10 +192,18 @@ void GetBestParametersFromJSONFile(const std::string& file_name,
         const auto params_split = split(config, '=');
         if (params_split.size() != 2) { break; }
         const auto parameter_name = params_split[0];
+        const auto parameter_value = static_cast<size_t>(std::stoi(params_split[1].c_str()));
         if (parameter_name != "PRECISION") {
-          const auto parameter_value = static_cast<size_t>(std::stoi(params_split[1].c_str()));
           printf("%s=%zu ", parameter_name.c_str(), parameter_value);
           parameters[parameter_name] = parameter_value;
+        }
+        else {
+          if (static_cast<size_t>(precision) != parameter_value) {
+            fprintf(stdout, "ERROR! }\n");
+            fprintf(stdout, "* Precision is not matching, continuing\n");
+            json_file.close();
+            return;
+          }
         }
       }
       fprintf(stdout, "}\n");

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -120,7 +120,7 @@ void OverrideParametersFromJSONFiles(const std::vector<std::string>& file_names,
                                      const cl_device_id device, const Precision precision) {
 
   // Retrieves the best parameters for each file from disk
-  BestParametersCollection all_parameters = {};
+  BestParametersCollection all_parameters;
   for (const auto json_file_name : file_names) {
     GetBestParametersFromJSONFile(json_file_name, all_parameters, precision);
   }

--- a/test/test_utilities.hpp
+++ b/test/test_utilities.hpp
@@ -15,7 +15,10 @@
 #ifndef CLBLAST_TEST_UTILITIES_H_
 #define CLBLAST_TEST_UTILITIES_H_
 
+#include <cstdlib>
 #include <string>
+#include <fstream>
+#include <sstream>
 
 #include "utilities/utilities.hpp"
 
@@ -108,6 +111,29 @@ Buffer<T> CreateInvalidBuffer(const Context& context, const size_t size) {
   #endif
   return Buffer<T>(raw_buffer);
 }
+
+// =================================================================================================
+
+template<typename Out>
+void split(const std::string &s, char delimiter, Out result) {
+  std::stringstream ss(s);
+  std::string item;
+  while (std::getline(ss, item, delimiter)) {
+    *(result++) = item;
+  }
+}
+
+inline std::vector<std::string> split(const std::string &s, char delimiter) {
+  std::vector<std::string> elements;
+  split(s, delimiter, std::back_inserter(elements));
+  return elements;
+}
+
+// =================================================================================================
+
+void OverrideParametersFromJSONFiles(const cl_device_id device, const Precision precision);
+void OverrideParametersFromJSONFile(const std::string& file_name,
+                                    const cl_device_id device, const Precision precision);
 
 // =================================================================================================
 } // namespace clblast

--- a/test/test_utilities.hpp
+++ b/test/test_utilities.hpp
@@ -138,7 +138,8 @@ using BestParametersCollection = std::unordered_map<std::string, BestParameters>
 void OverrideParametersFromJSONFiles(const std::vector<std::string>& file_names,
                                      const cl_device_id device, const Precision precision);
 void GetBestParametersFromJSONFile(const std::string& file_name,
-                                   BestParametersCollection& all_parameters);
+                                   BestParametersCollection& all_parameters,
+                                   const Precision precision);
 
 // =================================================================================================
 } // namespace clblast

--- a/test/test_utilities.hpp
+++ b/test/test_utilities.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <fstream>
 #include <sstream>
+#include <iterator>
 
 #include "utilities/utilities.hpp"
 

--- a/test/test_utilities.hpp
+++ b/test/test_utilities.hpp
@@ -32,6 +32,7 @@ constexpr auto kArgComparecublas = "cublas";
 constexpr auto kArgStepSize = "step";
 constexpr auto kArgNumSteps = "num_steps";
 constexpr auto kArgWarmUp = "warm_up";
+constexpr auto kArgTunerFiles = "tuner_files";
 
 // The test-specific arguments in string form
 constexpr auto kArgFullTest = "full_test";
@@ -131,9 +132,13 @@ inline std::vector<std::string> split(const std::string &s, char delimiter) {
 
 // =================================================================================================
 
-void OverrideParametersFromJSONFiles(const cl_device_id device, const Precision precision);
-void OverrideParametersFromJSONFile(const std::string& file_name,
-                                    const cl_device_id device, const Precision precision);
+using BestParameters = std::unordered_map<std::string,size_t>;
+using BestParametersCollection = std::unordered_map<std::string, BestParameters>;
+
+void OverrideParametersFromJSONFiles(const std::vector<std::string>& file_names,
+                                     const cl_device_id device, const Precision precision);
+void GetBestParametersFromJSONFile(const std::string& file_name,
+                                   BestParametersCollection& all_parameters);
 
 // =================================================================================================
 } // namespace clblast


### PR DESCRIPTION
This is for #210: overriding parameters in the performance clients directly by specifying a list of JSON files with tuner results.