### PR TITLE
Fix of multiple duplicates in documentation

### DIFF
--- a/doc/clblast.md
+++ b/doc/clblast.md
@@ -254,8 +254,6 @@ Arguments to DOT:
 * `const size_t n`: Integer size argument. This value must be positive.
 * `cl_mem dot_buffer`: OpenCL buffer to store the output dot vector.
 * `const size_t dot_offset`: The offset in elements from the start of the output dot vector.
-* `cl_mem dot_buffer`: OpenCL buffer to store the output dot vector.
-* `const size_t dot_offset`: The offset in elements from the start of the output dot vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
 * `const size_t x_offset`: The offset in elements from the start of the input x vector.
 * `const size_t x_inc`: Stride/increment of the input x vector. This value must be greater than 0.
@@ -301,8 +299,6 @@ Arguments to DOTU:
 * `const size_t n`: Integer size argument. This value must be positive.
 * `cl_mem dot_buffer`: OpenCL buffer to store the output dot vector.
 * `const size_t dot_offset`: The offset in elements from the start of the output dot vector.
-* `cl_mem dot_buffer`: OpenCL buffer to store the output dot vector.
-* `const size_t dot_offset`: The offset in elements from the start of the output dot vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
 * `const size_t x_offset`: The offset in elements from the start of the input x vector.
 * `const size_t x_inc`: Stride/increment of the input x vector. This value must be greater than 0.
@@ -346,8 +342,6 @@ CLBlastStatusCode CLBlastZdotc(const size_t n,
 Arguments to DOTC:
 
 * `const size_t n`: Integer size argument. This value must be positive.
-* `cl_mem dot_buffer`: OpenCL buffer to store the output dot vector.
-* `const size_t dot_offset`: The offset in elements from the start of the output dot vector.
 * `cl_mem dot_buffer`: OpenCL buffer to store the output dot vector.
 * `const size_t dot_offset`: The offset in elements from the start of the output dot vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
@@ -404,8 +398,6 @@ Arguments to NRM2:
 * `const size_t n`: Integer size argument. This value must be positive.
 * `cl_mem nrm2_buffer`: OpenCL buffer to store the output nrm2 vector.
 * `const size_t nrm2_offset`: The offset in elements from the start of the output nrm2 vector.
-* `cl_mem nrm2_buffer`: OpenCL buffer to store the output nrm2 vector.
-* `const size_t nrm2_offset`: The offset in elements from the start of the output nrm2 vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
 * `const size_t x_offset`: The offset in elements from the start of the input x vector.
 * `const size_t x_inc`: Stride/increment of the input x vector. This value must be greater than 0.
@@ -455,8 +447,6 @@ CLBlastStatusCode CLBlastHasum(const size_t n,
 Arguments to ASUM:
 
 * `const size_t n`: Integer size argument. This value must be positive.
-* `cl_mem asum_buffer`: OpenCL buffer to store the output asum vector.
-* `const size_t asum_offset`: The offset in elements from the start of the output asum vector.
 * `cl_mem asum_buffer`: OpenCL buffer to store the output asum vector.
 * `const size_t asum_offset`: The offset in elements from the start of the output asum vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
@@ -510,8 +500,6 @@ Arguments to SUM:
 * `const size_t n`: Integer size argument. This value must be positive.
 * `cl_mem sum_buffer`: OpenCL buffer to store the output sum vector.
 * `const size_t sum_offset`: The offset in elements from the start of the output sum vector.
-* `cl_mem sum_buffer`: OpenCL buffer to store the output sum vector.
-* `const size_t sum_offset`: The offset in elements from the start of the output sum vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
 * `const size_t x_offset`: The offset in elements from the start of the input x vector.
 * `const size_t x_inc`: Stride/increment of the input x vector. This value must be greater than 0.
@@ -561,8 +549,6 @@ CLBlastStatusCode CLBlastiHamax(const size_t n,
 Arguments to AMAX:
 
 * `const size_t n`: Integer size argument. This value must be positive.
-* `cl_mem imax_buffer`: OpenCL buffer to store the output imax vector.
-* `const size_t imax_offset`: The offset in elements from the start of the output imax vector.
 * `cl_mem imax_buffer`: OpenCL buffer to store the output imax vector.
 * `const size_t imax_offset`: The offset in elements from the start of the output imax vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
@@ -616,8 +602,6 @@ Arguments to AMIN:
 * `const size_t n`: Integer size argument. This value must be positive.
 * `cl_mem imin_buffer`: OpenCL buffer to store the output imin vector.
 * `const size_t imin_offset`: The offset in elements from the start of the output imin vector.
-* `cl_mem imin_buffer`: OpenCL buffer to store the output imin vector.
-* `const size_t imin_offset`: The offset in elements from the start of the output imin vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
 * `const size_t x_offset`: The offset in elements from the start of the input x vector.
 * `const size_t x_inc`: Stride/increment of the input x vector. This value must be greater than 0.
@@ -669,8 +653,6 @@ Arguments to MAX:
 * `const size_t n`: Integer size argument. This value must be positive.
 * `cl_mem imax_buffer`: OpenCL buffer to store the output imax vector.
 * `const size_t imax_offset`: The offset in elements from the start of the output imax vector.
-* `cl_mem imax_buffer`: OpenCL buffer to store the output imax vector.
-* `const size_t imax_offset`: The offset in elements from the start of the output imax vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.
 * `const size_t x_offset`: The offset in elements from the start of the input x vector.
 * `const size_t x_inc`: Stride/increment of the input x vector. This value must be greater than 0.
@@ -720,8 +702,6 @@ CLBlastStatusCode CLBlastiHmin(const size_t n,
 Arguments to MIN:
 
 * `const size_t n`: Integer size argument. This value must be positive.
-* `cl_mem imin_buffer`: OpenCL buffer to store the output imin vector.
-* `const size_t imin_offset`: The offset in elements from the start of the output imin vector.
 * `cl_mem imin_buffer`: OpenCL buffer to store the output imin vector.
 * `const size_t imin_offset`: The offset in elements from the start of the output imin vector.
 * `const cl_mem x_buffer`: OpenCL buffer to store the input x vector.

--- a/scripts/generator/generator/routine.py
+++ b/scripts/generator/generator/routine.py
@@ -806,7 +806,6 @@ class Routine:
         """Retrieves a combination of all the argument types"""
         return (self.options_doc() + self.sizes_doc() +
                 list(chain(*[self.buffer_doc(b) for b in self.scalar_buffers_first()])) +
-                list(chain(*[self.buffer_doc(b) for b in self.scalar_buffers_first()])) +
                 self.scalar_doc("alpha") +
                 list(chain(*[self.buffer_doc(b) for b in self.buffers_first()])) +
                 self.scalar_doc("beta") +


### PR DESCRIPTION
Hi!
Just noticed multiple duplicates in lines describing arguments. Most likely the result of a wrong mass find/replace operation in text editor.