### PR TITLE
Adding override parameters to pyclblast

### DIFF
--- a/scripts/generator/generator.py
+++ b/scripts/generator/generator.py
@@ -49,8 +49,8 @@ FILES = [
     "/src/clblast_cuda.cpp",
     "/src/pyclblast/src/pyclblast.pyx"
 ]
-HEADER_LINES = [123, 21, 127, 24, 29, 41, 29, 65, 32, 95, 21, 288]
-FOOTER_LINES = [41, 56, 112, 275, 6, 6, 6, 9, 2, 41, 55, 1]
+HEADER_LINES = [123, 21, 127, 24, 29, 41, 29, 65, 32, 95, 21, 290]
+FOOTER_LINES = [41, 56, 112, 275, 6, 6, 6, 9, 2, 41, 55, 37]
 HEADER_LINES_DOC = 0
 FOOTER_LINES_DOC = 158
 

--- a/src/pyclblast/samples/override_parameters.py
+++ b/src/pyclblast/samples/override_parameters.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# This file is part of the CLBlast project. The project is licensed under Apache Version 2.0.
+# This file follows the PEP8 Python style guide and uses a max-width of 100 characters per line.
+#
+# Author(s):
+#   Cedric Nugteren <www.cedricnugteren.nl>
+
+import numpy as np
+import pyopencl as cl
+from pyopencl.array import Array
+import pyclblast
+from datetime import datetime
+
+if __name__ == "__main__":
+
+    # Set up pyopencl:
+    ctx = cl.create_some_context()
+    queue = cl.CommandQueue(ctx)
+
+    # Set up a basic sgemm example:
+    m, n, k = 2, 3, 4
+    a = np.random.rand(m, k).astype(dtype=np.float32)
+    b = np.random.rand(k, n).astype(dtype=np.float32)
+    c = np.empty((m, n), np.float32)
+    cla = Array(queue, a.shape, a.dtype)
+    clb = Array(queue, b.shape, b.dtype)
+    clc = Array(queue, c.shape, c.dtype)
+    cla.set(a)
+    clb.set(b)
+    clc.set(c)
+
+    # Perform sgemm on these matrices, overriding the CLBlast parameters. In this example, we'll
+    # just change the 'MWG' parameter a couple of times:
+    params = { "KWG": 32, "KWI": 2, "MDIMA": 8, "MDIMC": 8, "MWG": 64, "NDIMB": 8, "NDIMC": 8,
+            "NWG": 64, "SA": 0, "SB": 0, "STRM": 0, "STRN": 0, "VWM": 4, "VWN": 1 }
+    for mwg in (32, 64, 256):
+        print("Running sgemm tuned with MWG = %d" % mwg)
+        params["MWG"] = mwg
+        pyclblast.override_parameters(ctx.devices[0], 'Xgemm', 32, params)
+        pyclblast.gemm(queue, m, n, k, cla, clb, clc, a_ld=k, b_ld=n, c_ld=n)
+        assert np.allclose(clc.get(), a.dot(b)), "uh-oh, xgemm isn't behaving correctly"

--- a/src/pyclblast/samples/sgemm.py
+++ b/src/pyclblast/samples/sgemm.py
@@ -10,6 +10,7 @@ import numpy as np
 import pyopencl as cl
 from pyopencl.array import Array
 import pyclblast
+from datetime import datetime
 
 # Settings for this sample
 dtype = 'float32'
@@ -19,7 +20,7 @@ ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
 
 print("# Setting up Numpy arrays")
-m, n, k = 2, 3, 4
+m, n, k = 128, 256, 512
 a = np.random.rand(m, k).astype(dtype=dtype)
 b = np.random.rand(k, n).astype(dtype=dtype)
 c = np.random.rand(m, n).astype(dtype=dtype)
@@ -34,5 +35,17 @@ clc.set(c)
 
 print("# Example level-3 operation: GEMM")
 pyclblast.gemm(queue, m, n, k, cla, clb, clc, a_ld=k, b_ld=n, c_ld=n)
-print("# Matrix C result: %s" % clc.get())
-print("# Expected result: %s" % (np.dot(a, b)))
+print("# PyCLBlast matrix result is correct?:", np.allclose(clc.get(), np.dot(a, b)))
+
+print("# GFLOPS when tuned with different values of MWG:")
+params = { "KWG": 32, "KWI": 2, "MDIMA": 8, "MDIMC": 8, "MWG": 64, "NDIMB": 8, "NDIMC": 8, "NWG": 64, "SA": 0, "SB": 0, "STRM": 0, "STRN": 0, "VWM": 4, "VWN": 1 }
+mwg = 1
+while mwg <= 256:
+    params["MWG"] = mwg
+    pyclblast.override_parameters(ctx.devices[0], 'Xgemm', 32, params)
+    for i in range(100):
+        if i == 10:
+            t0 = datetime.now()
+        pyclblast.gemm(queue, m, n, k, cla, clb, clc, a_ld=k, b_ld=n, c_ld=n)
+    print("#\tMWG = %-3d : %4d" % (mwg,  int(2 * m * n * k / ((datetime.now() - t0).total_seconds() / 100) / 1024 ** 3)))
+    mwg *= 4

--- a/src/pyclblast/samples/sgemm.py
+++ b/src/pyclblast/samples/sgemm.py
@@ -10,7 +10,6 @@ import numpy as np
 import pyopencl as cl
 from pyopencl.array import Array
 import pyclblast
-from datetime import datetime
 
 # Settings for this sample
 dtype = 'float32'
@@ -20,7 +19,7 @@ ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
 
 print("# Setting up Numpy arrays")
-m, n, k = 128, 256, 512
+m, n, k = 2, 3, 4
 a = np.random.rand(m, k).astype(dtype=dtype)
 b = np.random.rand(k, n).astype(dtype=dtype)
 c = np.random.rand(m, n).astype(dtype=dtype)
@@ -35,17 +34,5 @@ clc.set(c)
 
 print("# Example level-3 operation: GEMM")
 pyclblast.gemm(queue, m, n, k, cla, clb, clc, a_ld=k, b_ld=n, c_ld=n)
-print("# PyCLBlast matrix result is correct?:", np.allclose(clc.get(), np.dot(a, b)))
-
-print("# GFLOPS when tuned with different values of MWG:")
-params = { "KWG": 32, "KWI": 2, "MDIMA": 8, "MDIMC": 8, "MWG": 64, "NDIMB": 8, "NDIMC": 8, "NWG": 64, "SA": 0, "SB": 0, "STRM": 0, "STRN": 0, "VWM": 4, "VWN": 1 }
-mwg = 1
-while mwg <= 256:
-    params["MWG"] = mwg
-    pyclblast.override_parameters(ctx.devices[0], 'Xgemm', 32, params)
-    for i in range(100):
-        if i == 10:
-            t0 = datetime.now()
-        pyclblast.gemm(queue, m, n, k, cla, clb, clc, a_ld=k, b_ld=n, c_ld=n)
-    print("#\tMWG = %-3d : %4d" % (mwg,  int(2 * m * n * k / ((datetime.now() - t0).total_seconds() / 100) / 1024 ** 3)))
-    mwg *= 4
+print("# Matrix C result: %s" % clc.get())
+print("# Expected result: %s" % (np.dot(a, b)))

--- a/src/pyclblast/src/pyclblast.pyx
+++ b/src/pyclblast/src/pyclblast.pyx
@@ -2090,16 +2090,20 @@ from libc.stdlib cimport malloc, free
 from libc.string cimport strdup
 
 cdef extern from "clblast_c.h":
-    ctypedef void* cl_device_id
+    ctypedef struct _cl_device_id:
+        pass
+    ctypedef _cl_device_id* cl_device_id
+
     CLBlastStatusCode CLBlastOverrideParameters(const cl_device_id device, const char* kernel_name, const CLBlastPrecision precision, const size_t num_parameters, const char** parameters_names, const size_t* parameters_values)
 
-def override_parameters(ctx, kernel_name, precision, parameters):
+def override_parameters(device, kernel_name, precision, parameters):
     """
     precision = 16, 32, 64, 3232, 6464
     kernel name = unicode string
     parameters = 
     """
-    
+ 
+    cdef cl_device_id device_id = <cl_device_id><size_t>device.int_ptr
     cdef size_t n = len(parameters)
     cdef const char **parameter_names = <const char**> malloc(n * sizeof(char*))
     cdef size_t *parameter_values = <size_t*> malloc(n * sizeof(size_t))
@@ -2110,7 +2114,7 @@ def override_parameters(ctx, kernel_name, precision, parameters):
         parameter_names[i] = strdup(k.encode('ascii'))
         parameter_values[i] = v
     
-    err = CLBlastOverrideParameters((<cl_device_id> ctx.devices[0].ptr), kernel_name.encode('ascii'), precision, n, parameter_names, parameter_values)
+    err = CLBlastOverrideParameters(device_id, kernel_name.encode('ascii'), precision, n, parameter_names, parameter_values)
     if err != CLBlastSuccess:
         raise RuntimeError("PyCLBlast: 'OverrideParameters' failed: %s" % get_status_message(err))
 


### PR DESCRIPTION
As per #254 

Status:
- cython compiles
- but it gives a segfault when I try to call it with e.g.

```python
pyclblast.override_parameters(ctx, 'gemm', 32, {"KWG": 16, "KWI": 2, "MDIMA": 32, "MDIMC": 8, "MWG": 64, "NDIMB": 8, "NDIMC": 8, "NWG": 64, "PRECISION": 32, "SA": 1, "SB": 1, "STRM": 0, "STRN": 0, "VWM": 1, "VWN": 8})
```

My suspicion is with where I'm providing the `cl_device_id` ... I've got little idea what's going on here (I'm pretty green with C++ and can't even find where that's defined). That, or some nastiness like not converting strings nicely, etc. @CNugteren - any ideas?

Good references:
- https://lists.tiker.net/pipermail/pyopencl/2015-June/001890.html 
- https://lists.tiker.net/pipermail/pyopencl/2015-July/001903.html