### PR TITLE
Routine tuners read kernel JSON from disk

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Development (next version)
 - Improved the performance potential by adding a second tunable GEMM kernel with 2D register tiling
 - Added support for Intel specific subgroup shuffling extensions for faster GEMM on Intel GPUs
 - Re-added a local memory size constraint to the tuners
+- The routine tuners now automatically pick up tuning results from disk from the kernel tuners
 - Updated and reorganised the CLBlast documentation
 - Added a 'canary' region to check for overflows in the tuner and tests (insipred by clARMOR)
 - Fixed an access violation when compiled with Visual Studio upon releasing the OpenCL program

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,7 +388,6 @@ if(TUNERS)
       src/utilities/clblast_exceptions.cpp
       src/utilities/timing.cpp
       src/utilities/utilities.cpp
-      test/test_utilities.cpp
       src/tuning/configurations.cpp
       src/tuning/tuning.cpp
       src/kernel_preprocessor.cpp)
@@ -397,7 +396,6 @@ if(TUNERS)
       src/utilities/clblast_exceptions.hpp
       src/utilities/timing.hpp
       src/utilities/utilities.hpp
-      test/test_utilities.hpp
       src/tuning/configurations.hpp
       src/tuning/tuning.hpp
       src/tuning/routines/routine_tuner.hpp
@@ -426,9 +424,9 @@ if(TUNERS)
     install(TARGETS clblast_tuner_${KERNEL} DESTINATION bin)
   endforeach()
   foreach(ROUTINE_TUNER ${ROUTINE_TUNERS})
-    add_executable(clblast_tuner_routine_${ROUTINE_TUNER} ${TUNERS_COMMON} src/tuning/routines/${ROUTINE_TUNER}.cpp)
+    add_executable(clblast_tuner_routine_${ROUTINE_TUNER} ${TUNERS_COMMON} src/tuning/routines/${ROUTINE_TUNER}.cpp test/test_utilities.cpp)
     target_link_libraries(clblast_tuner_routine_${ROUTINE_TUNER} clblast)
-    target_include_directories(clblast_tuner_routine_${ROUTINE_TUNER} PUBLIC $<TARGET_PROPERTY:clblast,INTERFACE_INCLUDE_DIRECTORIES> ${API_INCLUDE_DIRS})
+    target_include_directories(clblast_tuner_routine_${ROUTINE_TUNER} PUBLIC $<TARGET_PROPERTY:clblast,INTERFACE_INCLUDE_DIRECTORIES> ${API_INCLUDE_DIRS} ${clblast_SOURCE_DIR})
     install(TARGETS clblast_tuner_routine_${ROUTINE_TUNER} DESTINATION bin)
   endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,7 @@ if(TUNERS)
       src/utilities/clblast_exceptions.cpp
       src/utilities/timing.cpp
       src/utilities/utilities.cpp
+      test/test_utilities.cpp
       src/tuning/configurations.cpp
       src/tuning/tuning.cpp
       src/kernel_preprocessor.cpp)
@@ -396,6 +397,7 @@ if(TUNERS)
       src/utilities/clblast_exceptions.hpp
       src/utilities/timing.hpp
       src/utilities/utilities.hpp
+      test/test_utilities.hpp
       src/tuning/configurations.hpp
       src/tuning/tuning.hpp
       src/tuning/routines/routine_tuner.hpp
@@ -438,6 +440,12 @@ if(TUNERS)
       set(ALLTUNERS ${ALLTUNERS} COMMAND clblast_tuner_${KERNEL} -precision ${PRECISION})
     endforeach()
     set(ALLTUNERSDEPENDS clblast_tuner_${KERNEL})
+  endforeach()
+  foreach(ROUTINE_TUNER ${ROUTINE_TUNERS})
+    foreach(PRECISION ${PRECISIONS})
+      set(ALLTUNERS ${ALLTUNERS} COMMAND clblast_tuner_routine_${ROUTINE_TUNER} -precision ${PRECISION})
+    endforeach()
+    set(ALLTUNERSDEPENDS clblast_tuner_routine_${ROUTINE_TUNER})
   endforeach()
   add_custom_target(alltuners ${ALLTUNERS} DEPENDS ${ALLTUNERSDEPENDS})
 

--- a/doc/tuning.md
+++ b/doc/tuning.md
@@ -82,7 +82,7 @@ Compiling with `-DTUNERS=ON` will generate a number of tuners, each named `clbla
 
 The kernels `gemm` and `gemm_direct` have too many parameters to explore. Therefore, they will run in two stages: a first stage with a fixed limited number of parameter combinations, and a second stage with a random selection from a much larger search space. The random fraction is determined by the `fraction` argument on the command-line.
 
-There are also several routine-level tuners. They tune inter-kernel parameters and should only be run after the kernels are tuned. An example is the GEMM routine tuner, which determines when to use the direct or the in-direct GEMM kernel.
+There are also several routine-level tuners. They tune inter-kernel parameters and should only be run after the kernels are tuned. However, they do automatically pick up kernel tuning results from the current folder if there are any. An example is the GEMM routine tuner, which determines when to use the direct or the in-direct GEMM kernel.
 
 
 Using the tuning results
@@ -99,8 +99,6 @@ In summary, tuning the entire library for your device can be done as follows (st
     make alltuners
     python ../scripts/database/database.py . ..
     make
-
-After the kernels are tuned, you can run the `clblast_tuner_routine_xgemm` tuner to optimize the high-level GEMM routine, i.e. selecting which method to use: the direct kernel or the in-direct kernel.
 
 
 Tuning using the API (advanced users only)

--- a/src/tuning/routines/xgemm.cpp
+++ b/src/tuning/routines/xgemm.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 
 #include "utilities/utilities.hpp"
-#include "../test/test_utilities.hpp"
+#include "test/test_utilities.hpp"
 #include "tuning/routines/routine_tuner.hpp"
 
 namespace clblast {

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -171,6 +171,7 @@ void GetBestParametersFromJSONFile(const std::string& file_name,
       kernel_family.erase(std::remove(kernel_family.begin(), kernel_family.end(), '1'), kernel_family.end());
       kernel_family.erase(std::remove(kernel_family.begin(), kernel_family.end(), '2'), kernel_family.end());
       kernel_family.erase(std::remove(kernel_family.begin(), kernel_family.end(), '3'), kernel_family.end());
+      if (kernel_family == "Xgemmdirect") { kernel_family = "XgemmDirect"; } // more kinds of mismatches
     }
 
     // Retrieves the best-parameters and sets the override


### PR DESCRIPTION
The GEMM routine tuner requires pre-tuned GEMM kernels. This is now automatically picked-up from disk and is no longer a two-stage process:
- The GEMM routine tuner checks for existing relevant JSON tuning files in the current folder. If there are any, they are picked-up and the parameters are set to be used.
- If no relevant GEMM kernel tuning parameters are found on disk, a message is printed to screen to inform the user that it is assumed that those kernels are already pre-tuned for. 
- The routine tuners are now part of the alltuners process. Although they still need to be run at the end, there is no intermediate manual step required. 