### PR TITLE
Disabled calls to clReleaseProgram under Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 
+Development (next version)
+- Fixed an access violation under Windows upon releasing the OpenCL program when the driver is already unloaded
+
 Version 1.4.0
 - Added Python interface to CLBlast 'PyCLBlast'
 - Added CLBlast to Ubuntu PPA and macOS Homebrew package managers

--- a/src/clpp11.hpp
+++ b/src/clpp11.hpp
@@ -463,7 +463,9 @@ class Program {
 
   // Clean-up
   ~Program() {
-    if (program_) { CheckErrorDtor(clReleaseProgram(program_)); }
+    #ifndef _MSC_VER // causes an access violation under Windows when the driver is already unloaded
+      if (program_) { CheckErrorDtor(clReleaseProgram(program_)); }
+    #endif
   }
 
   // Compiles the device program and checks whether or not there are any warnings/errors


### PR DESCRIPTION
This is to avoid segfaults when the OpenCL driver unloads first, known to happen under Windows.