### PR TITLE
Tuners now check for valid local thread size

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 
 Development (next version)
 - Added support for shuffle instructions for NVIDIA GPUs (thanks to 'tyler-utah')
+- The tuners now check beforehand on invalid local thread sizes and skip those completely
 - Fixed an issue with AMD GPUs and the new GEMMK == 1 kernel
 - Various minor fixes and enhancements
 

--- a/src/tuning/configurations.hpp
+++ b/src/tuning/configurations.hpp
@@ -50,6 +50,9 @@ struct LocalMemSizeInfo {
 // function to find all configurations. It also applies the user-defined constraints within.
 std::vector<Configuration> SetConfigurations(const Device& device,
                                              const std::vector<Parameter> parameters,
+                                             const std::vector<size_t>& local_size_base,
+                                             const TransformVector& mul_local_config,
+                                             const TransformVector& div_local_config,
                                              const Constraints& constraints,
                                              const LocalMemSizeInfo& local_mem_size_info);
 
@@ -58,11 +61,16 @@ std::vector<Configuration> SetConfigurations(const Device& device,
 // At the end of each chain (when all parameters are considered), the function stores the result
 // into the configuration list.
 void PopulateConfigurations(const std::vector<Parameter> &parameters,
+                            const std::vector<size_t> local_size_base,
+                            const TransformVector& mul_local_config,
+                            const TransformVector& div_local_config,
                             const size_t index, const Configuration &config,
                             std::vector<Configuration> &configuration,
                             const size_t local_mem_max,
                             const Constraints& constraints,
-                            const LocalMemSizeInfo& local_mem_size_info);
+                            const LocalMemSizeInfo& local_mem_size_info,
+                            const std::vector<size_t>& max_work_item_sizes,
+                            const size_t max_work_group_size);
 
 // Loops over all user-defined constraints to check whether or not the configuration is valid.
 // Assumes initially all configurations are valid, then returns false if one of the constraints has
@@ -71,7 +79,12 @@ void PopulateConfigurations(const std::vector<Parameter> &parameters,
 bool ValidConfiguration(const Configuration &config,
                         const size_t local_mem_max,
                         const Constraints& constraints,
-                        const LocalMemSizeInfo& local_mem_size_info);
+                        const LocalMemSizeInfo& local_mem_size_info,
+                        const std::vector<size_t> local_size_base,
+                        const TransformVector& mul_local_config,
+                        const TransformVector& div_local_config,
+                        const std::vector<size_t>& max_work_item_sizes,
+                        const size_t max_work_group_size);
 
 // Processes multipliers and dividers to obtain the final thread configuration
 std::vector<size_t> SetThreadConfiguration(const Configuration& config,

--- a/src/tuning/kernels/xgemm.cpp
+++ b/src/tuning/kernels/xgemm.cpp
@@ -33,9 +33,13 @@ void StartVariation(int argc, char *argv[]) {
 
 // Main function (not within the clblast namespace)
 int main(int argc, char *argv[]) {
+  printf("* (1/4) Tuning main GEMM kernel (GEMMK == 0) for fixed set of parameters\n\n");
   StartVariation<1>(argc, argv);
+  printf("* (2/4) Tuning main GEMM kernel (GEMMK == 0) for random parameters out of larger set\n\n");
   StartVariation<2>(argc, argv);
+  printf("* (3/4) Tuning secondary GEMM kernel (GEMMK == 1) for fixed set of parameters\n\n");
   StartVariation<11>(argc, argv);
+  printf("* (4/4) Tuning secondary GEMM kernel (GEMMK == 1) for random parameters out of larger set\n\n");
   StartVariation<12>(argc, argv);
   return 0;
 }

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -172,7 +172,8 @@ void Tuner(int argc, char* argv[], const int V,
   }
 
   // Sets the tunable parameters and their possible values
-  auto configurations = SetConfigurations(device, settings.parameters,
+  auto configurations = SetConfigurations(device, settings.parameters, settings.local_size,
+                                          settings.mul_local, settings.div_local,
                                           SetConstraints(V), ComputeLocalMemSize(V));
   printf("* Found %s%zu configuration(s)%s\n",
          kPrintMessage.c_str(), configurations.size(), kPrintEnd.c_str());

--- a/src/tuning/tuning_api.cpp
+++ b/src/tuning/tuning_api.cpp
@@ -264,7 +264,8 @@ StatusCode TunerAPI(Queue &queue, const Arguments<T> &args, const int V,
   }
 
   // Sets the tunable parameters and their possible values
-  auto configurations = SetConfigurations(device, settings.parameters,
+  auto configurations = SetConfigurations(device, settings.parameters, settings.local_size,
+                                          settings.mul_local, settings.div_local,
                                           SetConstraints(V), ComputeLocalMemSize(V));
 
   // Select the search method (full search or a random fraction)


### PR DESCRIPTION
The tuners now check for a valid local thread configuration beforehand. This saves compilation time in case kernels won't run anyway, and prevent potential issues such as #303. Also makes sure more valid configurations are explored during random parameter search.