### PR TITLE
Reduced number of TestMatrix calls for the batched xgemm routines.

### DIFF
--- a/src/routines/levelx/xgemmbatched.cpp
+++ b/src/routines/levelx/xgemmbatched.cpp
@@ -79,11 +79,9 @@ void XgemmBatched<T>::DoGemmBatched(const Layout layout, const Transpose a_trans
                              gemm_kernel_id);
 
   // Tests the matrices for validity
-  for (auto batch = size_t{0}; batch < batch_count; ++batch) {
-    TestMatrixA(a_one, a_two, a_buffer, a_offsets[batch], a_ld, false); // don't test for invalid LD
-    TestMatrixB(b_one, b_two, b_buffer, b_offsets[batch], b_ld, false); // don't test for invalid LD
-    TestMatrixC(c_one, c_two, c_buffer, c_offsets[batch], c_ld);
-  }
+  TestBatchedMatrixA(a_one, a_two, a_buffer, a_offsets, a_ld, false); // don't test for invalid LD
+  TestBatchedMatrixB(b_one, b_two, b_buffer, b_offsets, b_ld, false); // don't test for invalid LD
+  TestBatchedMatrixC(c_one, c_two, c_buffer, c_offsets, c_ld);
 
   // Upload the scalar arguments to the device
   auto alphas_device = Buffer<T>(context_, BufferAccess::kReadWrite, batch_count);

--- a/src/routines/levelx/xgemmstridedbatched.cpp
+++ b/src/routines/levelx/xgemmstridedbatched.cpp
@@ -78,11 +78,9 @@ void XgemmStridedBatched<T>::DoGemmStridedBatched(const Layout layout, const Tra
                              gemm_kernel_id);
 
   // Tests the matrices for validity
-  for (auto batch = size_t{0}; batch < batch_count; ++batch) {
-    TestMatrixA(a_one, a_two, a_buffer, a_offset + a_stride * batch, a_ld);
-    TestMatrixB(b_one, b_two, b_buffer, b_offset + b_stride * batch, b_ld);
-    TestMatrixC(c_one, c_two, c_buffer, c_offset + c_stride * batch, c_ld);
-  }
+  TestStridedBatchedMatrixA(a_one, a_two, a_buffer, a_offset, a_stride, batch_count, a_ld);
+  TestStridedBatchedMatrixB(b_one, b_two, b_buffer, b_offset, b_stride, batch_count, b_ld);
+  TestStridedBatchedMatrixC(c_one, c_two, c_buffer, c_offset, c_stride, batch_count, c_ld);
 
   // Selects which version of the batched GEMM to run
   if (do_gemm_direct) { // single generic kernel

--- a/src/utilities/buffer_test.hpp
+++ b/src/utilities/buffer_test.hpp
@@ -134,6 +134,35 @@ void TestBatchedMatrixC(const size_t one, const size_t two, const Buffer<T>& buf
 }
 
 // =================================================================================================
+
+// Tests matrix 'A' for validity in a strided batched setting
+template <typename T>
+void TestStridedBatchedMatrixA(const size_t one, const size_t two, const Buffer<T>& buffer,
+                               const size_t offset, const size_t stride, const size_t batch_count,
+                               const size_t ld, const bool test_lead_dim = true) {
+  const auto last_batch_offset = (batch_count - 1) * stride;
+  TestMatrixA(one, two, buffer, offset + last_batch_offset, ld, test_lead_dim);
+}
+
+// Tests matrix 'B' for validity in a strided batched setting
+template <typename T>
+void TestStridedBatchedMatrixB(const size_t one, const size_t two, const Buffer<T>& buffer,
+                               const size_t offset, const size_t stride, const size_t batch_count,
+                               const size_t ld, const bool test_lead_dim = true) {
+  const auto last_batch_offset = (batch_count - 1) * stride;
+  TestMatrixB(one, two, buffer, offset + last_batch_offset, ld, test_lead_dim);
+}
+
+// Tests matrix 'C' for validity in a strided batched setting
+template <typename T>
+void TestStridedBatchedMatrixC(const size_t one, const size_t two, const Buffer<T>& buffer,
+                               const size_t offset, const size_t stride, const size_t batch_count,
+                               const size_t ld) {
+  const auto last_batch_offset = (batch_count - 1) * stride;
+  TestMatrixC(one, two, buffer, offset + last_batch_offset, ld);
+}
+
+// =================================================================================================
 } // namespace clblast
 
 // CLBLAST_BUFFER_TEST_H_

--- a/src/utilities/buffer_test.hpp
+++ b/src/utilities/buffer_test.hpp
@@ -15,6 +15,9 @@
 #ifndef CLBLAST_BUFFER_TEST_H_
 #define CLBLAST_BUFFER_TEST_H_
 
+#include <algorithm>
+#include <vector>
+
 #include "utilities/utilities.hpp"
 
 namespace clblast {
@@ -102,6 +105,32 @@ void TestVectorIndex(const size_t n, const Buffer<T> &buffer, const size_t offse
     const auto required_size = (n + offset) * sizeof(T);
     if (buffer.GetSize() < required_size) { throw BLASError(StatusCode::kInsufficientMemoryScalar); }
   } catch (const Error<std::runtime_error> &e) { throw BLASError(StatusCode::kInvalidVectorScalar, e.what()); }
+}
+
+// =================================================================================================
+
+// Tests matrix 'A' for validity in a batched setting
+template <typename T>
+void TestBatchedMatrixA(const size_t one, const size_t two, const Buffer<T>& buffer,
+                        const std::vector<size_t> &offsets, const size_t ld, const bool test_lead_dim = true) {
+  const auto max_offset = *std::max_element(offsets.begin(), offsets.end());
+  TestMatrixA(one, two, buffer, max_offset, ld, test_lead_dim);
+}
+
+// Tests matrix 'B' for validity in a batched setting
+template <typename T>
+void TestBatchedMatrixB(const size_t one, const size_t two, const Buffer<T>& buffer,
+                        const std::vector<size_t>& offsets, const size_t ld, const bool test_lead_dim = true) {
+  const auto max_offset = *std::max_element(offsets.begin(), offsets.end());
+  TestMatrixB(one, two, buffer, max_offset, ld, test_lead_dim);
+}
+
+// Tests matrix 'C' for validity in a batched setting
+template <typename T>
+void TestBatchedMatrixC(const size_t one, const size_t two, const Buffer<T>& buffer,
+                        const std::vector<size_t>& offsets, const size_t ld) {
+  const auto max_offset = *std::max_element(offsets.begin(), offsets.end());
+  TestMatrixC(one, two, buffer, max_offset, ld);
 }
 
 // =================================================================================================


### PR DESCRIPTION
Same level of guarantees to the previous looped test is given by testing the worst case scenario, only, reducing the TestMatrix call count from the number of batches to one, allowing for much higher batch counts without affecting performance.