### PR TITLE
Use reference types to prevent unnecessary copying

### DIFF
--- a/src/kernel_preprocessor.cpp
+++ b/src/kernel_preprocessor.cpp
@@ -218,7 +218,7 @@ void ArrayToRegister(std::string &source_line, const DefinesIntMap& defines,
                      const std::unordered_map<std::string, size_t>& arrays_to_registers,
                      const size_t num_brackets) {
 
-  for (const auto array_name_map : arrays_to_registers) {  // only if marked to be promoted
+  for (const auto& array_name_map : arrays_to_registers) {  // only if marked to be promoted
 
     // Outside of a function
     if (num_brackets == 0) {

--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -62,7 +62,7 @@ void PrintTimingsToFileAsJSON(const std::string &filename,
     fprintf(file, "      \"parameters\": {");
     auto num_configs = result.config.size();
     auto p = size_t{0};
-    for (const auto parameter : result.config) {
+    for (const auto& parameter : result.config) {
       fprintf(file, "\"%s\": %zu", parameter.first.c_str(), parameter.second);
       if (p < num_configs -1 ) { fprintf(file, ","); }
       ++p;
@@ -336,7 +336,7 @@ void Tuner(int argc, char* argv[], const int V,
       printf(" %6.1lf |", settings.metric_amount / (time_ms * 1.0e6));
       printf("     %sresults match%s |\n", kPrintSuccess.c_str(), kPrintEnd.c_str());
     }
-    catch (CLCudaAPIBuildError) {
+    catch (CLCudaAPIBuildError&) {
       const auto status_code = DispatchExceptionCatchAll(true);
       printf("  %scompilation error: %5d%s     |",
              kPrintError.c_str(), static_cast<int>(status_code), kPrintEnd.c_str());
@@ -365,7 +365,7 @@ void Tuner(int argc, char* argv[], const int V,
 
   // Computes and prints some other statistics
   auto average_ms = 0.0;
-  for (const auto result : results) { average_ms += result.score; }
+  for (const auto& result : results) { average_ms += result.score; }
   average_ms /= results.size();
   printf("\n");
   printf("* Got average result of %.2lf ms", average_ms);
@@ -380,7 +380,7 @@ void Tuner(int argc, char* argv[], const int V,
   printf("* Best parameters: ");
   auto best_string = std::string{""};
   auto i = size_t{0};
-  for (const auto config : best_configuration->config) {
+  for (const auto& config : best_configuration->config) {
     best_string += "" + config.first + "=" + ToString(config.second);
     if (i < best_configuration->config.size() - 1) { best_string += " "; }
     ++i;

--- a/src/tuning/tuning_api.cpp
+++ b/src/tuning/tuning_api.cpp
@@ -374,7 +374,7 @@ StatusCode TunerAPI(Queue &queue, const Arguments<T> &args, const int V,
   if (best_time_ms == 0.0) { return StatusCode::kUnexpectedError; }
 
   // Stores the best parameters
-  for (const auto config : best_configuration->config) {
+  for (const auto& config : best_configuration->config) {
     parameters[config.first] = config.second;
   }
   return StatusCode::kSuccess;

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -131,7 +131,7 @@ void OverrideParametersFromJSONFiles(const std::vector<std::string>& file_names,
 
   // Retrieves the best parameters for each file from disk
   BestParametersCollection all_parameters;
-  for (const auto json_file_name : file_names) {
+  for (const auto& json_file_name : file_names) {
     GetBestParametersFromJSONFile(json_file_name, all_parameters, precision);
   }
 
@@ -199,7 +199,7 @@ void GetBestParametersFromJSONFile(const std::string& file_name,
 
       // Creates the list of parameters
       fprintf(stdout, "* Found parameters for kernel '%s': { ", kernel_family.c_str());
-      for (const auto config : config_split) {
+      for (const auto& config : config_split) {
         const auto params_split = split(config, '=');
         if (params_split.size() != 2) { break; }
         const auto parameter_name = params_split[0];


### PR DESCRIPTION
While building version 1.5.2 for Fedora, I noticed a number of compiler warnings of this form:
```
/builddir/build/BUILD/CLBlast-1.5.2/src/kernel_preprocessor.cpp:221:19: warning: loop variable 'array_name_map' creates a copy from type 'const std::pair<const std::__cxx11::basic_string<char>, long unsigned int>' [-Wrange-loop-construct]
  221 |   for (const auto array_name_map : arrays_to_registers) {  // only if marked to be promoted
      |                   ^~~~~~~~~~~~~~
/builddir/build/BUILD/CLBlast-1.5.2/src/kernel_preprocessor.cpp:221:19: note: use reference type to prevent copying
  221 |   for (const auto array_name_map : arrays_to_registers) {  // only if marked to be promoted
      |                   ^~~~~~~~~~~~~~
      |                   &
```

This patch uses references types as indicated to prevent unnecessary copying.