### PR TITLE
Correct capitalization typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,7 +360,7 @@ elseif(CUDA)
 endif()
 
 # Installs the config for find_package in dependent projects
-install(EXPORT CLBlast DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CLBLast FILE CLBlastConfig.cmake)
+install(EXPORT CLBlast DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CLBlast FILE CLBlastConfig.cmake)
 
 # Install pkg-config file on Linux
 if(UNIX)

--- a/include/clblast.h
+++ b/include/clblast.h
@@ -710,7 +710,7 @@ StatusCode GemmTempBufferSize(const Layout layout, const Transpose a_transpose, 
 // for the same device. This cache can be cleared to free up system memory or in case of debugging.
 StatusCode PUBLIC_API ClearCache();
 
-// The cache can also be pre-initialized for a specific device with all possible CLBLast kernels.
+// The cache can also be pre-initialized for a specific device with all possible CLBlast kernels.
 // Further CLBlast routine calls will then run at maximum speed.
 StatusCode PUBLIC_API FillCache(const cl_device_id device);
 

--- a/include/clblast_c.h
+++ b/include/clblast_c.h
@@ -1685,7 +1685,7 @@ CLBlastStatusCode PUBLIC_API CLBlastHGemmTempBufferSize(const CLBlastLayout layo
 // for the same device. This cache can be cleared to free up system memory or in case of debugging.
 CLBlastStatusCode PUBLIC_API CLBlastClearCache();
 
-// The cache can also be pre-initialized for a specific device with all possible CLBLast kernels.
+// The cache can also be pre-initialized for a specific device with all possible CLBlast kernels.
 // Further CLBlast routine calls will then run at maximum speed.
 CLBlastStatusCode PUBLIC_API CLBlastFillCache(const cl_device_id device);
 

--- a/include/clblast_cuda.h
+++ b/include/clblast_cuda.h
@@ -677,7 +677,7 @@ StatusCode GemmTempBufferSize(const Layout layout, const Transpose a_transpose, 
 // for the same device. This cache can be cleared to free up system memory or in case of debugging.
 StatusCode PUBLIC_API ClearCache();
 
-// The cache can also be pre-initialized for a specific device with all possible CLBLast kernels.
+// The cache can also be pre-initialized for a specific device with all possible CLBlast kernels.
 // Further CLBlast routine calls will then run at maximum speed.
 StatusCode PUBLIC_API FillCache(const CUdevice device);
 


### PR DESCRIPTION
The CLBlastConfig.cmake file was installed to a directory named
CLBLast (notice second capital l), which can cause issues for CMake's
search path when looking for CLBlast on the system.

This commit also fixes other occurrences of the wrong capitalization,
all of it purely cosmetic (i.e. in comments).