### PR TITLE
android.hpp: custom header guard _clang_

### DIFF
--- a/src/utilities/android.hpp
+++ b/src/utilities/android.hpp
@@ -14,7 +14,7 @@
 
 #ifndef CLBLAST_ANDROID_HPP_
 #define CLBLAST_ANDROID_HPP_
-
+#ifndef __clang__ // not to include custom impl to avoid ambiguous definition
 // =================================================================================================
 
 #include <cstdlib>
@@ -42,6 +42,6 @@ inline int stoi( const std::string& str, std::size_t* pos = 0, int base = 10) {
 }
 
 // =================================================================================================
-
+#endif // clang header guard
 // CLBLAST_ANDROID_HPP_
 #endif


### PR DESCRIPTION
While compiling on android with clang 13 (thru Termux), this file causes problem, as clang gives the implementation. causing redef.
In order not to have ambiguous definitions, exclude the functions for other compilers