### PR TITLE
Add logic to find intel OpenMP on oneMKL.

### DIFF
--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -25,6 +25,8 @@
 set(MKL_HINTS
   ${MKL_ROOT}
   $ENV{MKL_ROOT}
+  $ENV{MKLROOT}
+  $ENV{CMPLR_ROOT}
 )
 set(MKL_PATHS
   /usr
@@ -47,11 +49,14 @@ find_path(MKL_INCLUDE_DIRS
 mark_as_advanced(MKL_INCLUDE_DIRS)
 
 # Finds the libraries
-set(MKL_LIB_SUFFIXES lib lib64 lib/x86_64 lib/x64 lib/x86 lib/Win32 lib/import lib64/import lib/intel64)
+set(MKL_LIB_SUFFIXES
+  lib lib64 lib/x86_64 lib/x64 lib/x86 lib/Win32 lib/import lib64/import lib/intel64
+  linux/compiler/lib/intel64
+  windows/compiler/lib/intel64)
 find_library(MKL_LIBRARIES_LP64 NAMES mkl_intel_lp64 HINTS ${MKL_HINTS} PATH_SUFFIXES ${MKL_LIB_SUFFIXES} PATHS ${MKL_PATHS} DOC "Intel MKL lp64 library")
 find_library(MKL_LIBRARIES_THREAD NAMES mkl_intel_thread HINTS ${MKL_HINTS} PATH_SUFFIXES ${MKL_LIB_SUFFIXES} PATHS ${MKL_PATHS} DOC "Intel MKL thread library")
 find_library(MKL_LIBRARIES_CORE NAMES mkl_core HINTS ${MKL_HINTS} PATH_SUFFIXES ${MKL_LIB_SUFFIXES} PATHS ${MKL_PATHS} DOC "Intel MKL core library")
-find_library(MKL_LIBRARIES_OMP NAMES iomp5 HINTS ${MKL_HINTS} PATH_SUFFIXES ${MKL_LIB_SUFFIXES} PATHS ${MKL_PATHS} DOC "Intel OpenMP library")
+find_library(MKL_LIBRARIES_OMP NAMES iomp5 libiomp5md HINTS ${MKL_HINTS} PATH_SUFFIXES ${MKL_LIB_SUFFIXES} PATHS ${MKL_PATHS} DOC "Intel OpenMP library")
 set(MKL_LIBRARIES ${MKL_LIBRARIES_LP64} ${MKL_LIBRARIES_THREAD} ${MKL_LIBRARIES_CORE} ${MKL_LIBRARIES_OMP})
 mark_as_advanced(MKL_LIBRARIES)
 
@@ -59,14 +64,14 @@ mark_as_advanced(MKL_LIBRARIES)
 
 # Notification messages
 if(NOT MKL_INCLUDE_DIRS)
-    message(STATUS "Could NOT find 'mkl_cblas.h', install MKL or set MKL_ROOT")
+    message(STATUS "Could NOT find 'mkl_cblas.h', install it or set MKLROOT and CMPLR_ROOT or source setvars.sh or setvars.bat")
 endif()
 if(NOT MKL_LIBRARIES)
-    message(STATUS "Could NOT find the Intel MKL BLAS library, install it or set MKL_ROOT")
+    message(STATUS "Could NOT find the Intel MKL BLAS library, install it or set MKLROOT and CMPLR_ROOT or source setvars.sh or setvars.bat")
 endif()
 
 # Determines whether or not MKL was found
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INCLUDE_DIRS MKL_LIBRARIES)
+find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INCLUDE_DIRS MKL_LIBRARIES_LP64 MKL_LIBRARIES_THREAD MKL_LIBRARIES_CORE MKL_LIBRARIES_OMP)
 
 # ==================================================================================================


### PR DESCRIPTION
MKL now stores the iomp5 library in the compiler library directory. This change updates the script to find the libiomp5 in the appropriate mkl directory on Linux and Windows.

I just tried to make a minimal change to the FindMKL script. ArrayFire has a more robust version of this in the ArrayFire repo. You can check it out here: https://github.com/arrayfire/arrayfire/blob/master/CMakeModules/FindMKL.cmake

It may require a more recent version of CMake but I am not sure what that is. 