### PR TITLE
Fix API inconsistency in cupp11.hpp

### DIFF
--- a/src/cupp11.hpp
+++ b/src/cupp11.hpp
@@ -647,7 +647,8 @@ public:
   }
 
   // Copies the contents of this buffer into another device buffer
-  void CopyToAsync(const Queue &queue, const size_t size, const Buffer<T> &destination) const {
+  void CopyToAsync(const Queue &queue, const size_t size, const Buffer<T> &destination,
+                   EventPointer event = nullptr) const {
     CheckError(cuMemcpyDtoDAsync(destination(), *buffer_, size*sizeof(T), queue()));
   }
   void CopyTo(const Queue &queue, const size_t size, const Buffer<T> &destination) const {


### PR DESCRIPTION
The function `CopyToAsync` has an optional event argument in the OpenCL version, which is used in CLBlast. This makes the code not compile at all if CUDA (through cupp11.hpp`) is used as backend. This issue was found by a CLBlast user and reported privately by email. This PR should fix that.