### PR TITLE
Add Github Actions release script

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install requirements for Ubuntu
       run: |
         sudo apt-get update
-        sudo apt-get install -yq cmake ninja-build ocl-icd-opencl-dev opencl-c-headers libopenblas-dev --no-install-recommends
+        sudo apt-get install -yq ninja-build ocl-icd-opencl-dev opencl-c-headers libopenblas-dev --no-install-recommends
       if: ${{ matrix.config.os == 'ubuntu-latest' }}
 
     - name: Install requirements for macOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,10 @@ jobs:
     - name: Package the code
       run: |
         cmake --build build --target install
-        zip -r ${{env.RELEASE_NAME}}.zip ${{env.RELEASE_NAME}}
+        7z a -r ${{env.RELEASE_NAME}}.7z ${{env.RELEASE_NAME}}
 
     - name: Upload the release
       uses: actions/upload-artifact@v3
       with:
         name: ${{env.RELEASE_NAME}}
-        path: ${{env.RELEASE_NAME}}.zip
+        path: ${{env.RELEASE_NAME}}.7z

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: CLBlast release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version of the form 1.5.3"
+        required: true
+
+jobs:
+
+  release:
+
+    strategy:
+      matrix:
+        config: [
+          {name: linux, os: ubuntu-20.04, arch: x86_64, c_compiler: gcc-9, cpp_compiler: g++-9},
+          {name: macos, os: macos-11, arch: x86_64, c_compiler: clang, cpp_compiler: clang++},
+          {name: windows, os: windows-2019, arch: x64, c_compiler: cl, cpp_compiler: cl},
+        ]
+
+    runs-on: ${{ matrix.config.os }}
+
+    env:
+      RELEASE_NAME: CLBlast-${{ github.event.inputs.version }}-${{ matrix.config.name }}-${{ matrix.config.arch }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install requirements for Ubuntu
+      run: |
+        sudo apt-get update
+        sudo apt-get install -yq ocl-icd-opencl-dev opencl-c-headers --no-install-recommends
+      if: ${{ matrix.config.name == 'linux' }}
+
+    - name: Set up MSVC for Windows
+      uses: ilammy/msvc-dev-cmd@v1
+      if: ${{ matrix.config.name == 'windows' }}
+
+    - name: Run CMake for Linux and macOS
+      run: |
+        mkdir ${RELEASE_NAME}
+        export CC=${{ matrix.config.c_compiler }}
+        export CXX=${{ matrix.config.cpp_compiler }}
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${RELEASE_NAME}
+      if: ${{ matrix.config.name != 'windows' }}
+
+    - name: Run CMake for Windows
+      run: |
+        mkdir ${RELEASE_NAME}
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${RELEASE_NAME}
+      if: ${{ matrix.config.name == 'windows' }}
+
+    - name: Compile the code
+      run: cmake --build build
+
+    - name: Package the code
+      run: |
+        cmake --build build --target install
+        tar -cvf ${RELEASE_NAME}.tar.gz ${RELEASE_NAME}
+
+    - name: Upload the release
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${RELEASE_NAME}
+        path: ${RELEASE_NAME}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
 
     - name: Run CMake
       run: |
-        mkdir ${RELEASE_NAME}
+        mkdir ${{env.RELEASE_NAME}}
         export CC=${{ matrix.config.c_compiler }}
         export CXX=${{ matrix.config.cpp_compiler }}
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${RELEASE_NAME}
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${{env.RELEASE_NAME}}
 
     - name: Compile the code
       run: cmake --build build
@@ -47,13 +47,13 @@ jobs:
     - name: Package the code
       run: |
         cmake --build build --target install
-        tar -cvf ${RELEASE_NAME}.tar.gz ${RELEASE_NAME}
+        tar -cvf ${{env.RELEASE_NAME}}.tar.gz ${{env.RELEASE_NAME}}
 
     - name: Upload the release
       uses: actions/upload-artifact@v3
       with:
-        name: ${RELEASE_NAME}
-        path: ${RELEASE_NAME}.tar.gz
+        name: ${{env.RELEASE_NAME}}
+        path: ${{env.RELEASE_NAME}}.tar.gz
 
 
   release_windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       version:
         description: "Version of the form 1.5.3"
         required: true
+  pull_request: {}
 
 jobs:
 
@@ -22,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
 
     env:
-      RELEASE_NAME: CLBlast-${{ github.event.inputs.version }}-${{ matrix.config.name }}-${{ matrix.config.arch }}
+      RELEASE_NAME: CLBlast-test-version-${{ matrix.config.name }}-${{ matrix.config.arch }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Run CMake
       run: |
         mkdir ${{env.RELEASE_NAME}}
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${{env.RELEASE_NAME}}
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${{env.RELEASE_NAME}} -DOPENCL_ROOT=C:/vcpkg/packages/opencl_x64-windows
 
     - name: Compile the code
       run: cmake --build build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,16 @@ on:
         required: true
   pull_request: {}
 
+
 jobs:
 
-  release:
+  release_linux_and_macos:
 
     strategy:
       matrix:
         config: [
           {name: linux, os: ubuntu-20.04, arch: x86_64, c_compiler: gcc-9, cpp_compiler: g++-9},
           {name: macos, os: macos-11, arch: x86_64, c_compiler: clang, cpp_compiler: clang++},
-          {name: windows, os: windows-2019, arch: x64, c_compiler: cl, cpp_compiler: cl},
         ]
 
     runs-on: ${{ matrix.config.os }}
@@ -34,23 +34,12 @@ jobs:
         sudo apt-get install -yq ocl-icd-opencl-dev opencl-c-headers --no-install-recommends
       if: ${{ matrix.config.name == 'linux' }}
 
-    - name: Set up MSVC for Windows
-      uses: ilammy/msvc-dev-cmd@v1
-      if: ${{ matrix.config.name == 'windows' }}
-
-    - name: Run CMake for Linux and macOS
+    - name: Run CMake
       run: |
         mkdir ${RELEASE_NAME}
         export CC=${{ matrix.config.c_compiler }}
         export CXX=${{ matrix.config.cpp_compiler }}
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${RELEASE_NAME}
-      if: ${{ matrix.config.name != 'windows' }}
-
-    - name: Run CMake for Windows
-      run: |
-        mkdir ${RELEASE_NAME}
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${RELEASE_NAME}
-      if: ${{ matrix.config.name == 'windows' }}
 
     - name: Compile the code
       run: cmake --build build
@@ -65,3 +54,42 @@ jobs:
       with:
         name: ${RELEASE_NAME}
         path: ${RELEASE_NAME}.tar.gz
+
+
+  release_windows:
+
+    strategy:
+      matrix:
+        config: [
+          {name: windows, os: windows-2019, arch: x64},
+        ]
+
+    runs-on: ${{ matrix.config.os }}
+
+    env:
+      RELEASE_NAME: CLBlast-test-version-${{ matrix.config.name }}-${{ matrix.config.arch }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up MSVC
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Run CMake
+      run: |
+        mkdir ${{env.RELEASE_NAME}}
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${{env.RELEASE_NAME}}
+
+    - name: Compile the code
+      run: cmake --build build
+
+    - name: Package the code
+      run: |
+        cmake --build build --target install
+        zip -r ${{env.RELEASE_NAME}}.zip ${{env.RELEASE_NAME}}
+
+    - name: Upload the release
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{env.RELEASE_NAME}}
+        path: ${{env.RELEASE_NAME}}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       version:
         description: "Version of the form 1.5.3"
         required: true
-  pull_request: {}
 
 
 jobs:
@@ -23,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
 
     env:
-      RELEASE_NAME: CLBlast-test-version-${{ matrix.config.name }}-${{ matrix.config.arch }}
+      RELEASE_NAME: CLBlast-${{ github.event.inputs.version }}-${{ matrix.config.name }}-${{ matrix.config.arch }}
 
     steps:
     - uses: actions/checkout@v3
@@ -67,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
 
     env:
-      RELEASE_NAME: CLBlast-test-version-${{ matrix.config.name }}-${{ matrix.config.arch }}
+      RELEASE_NAME: CLBlast-${{ github.event.inputs.version }}-${{ matrix.config.name }}-${{ matrix.config.arch }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
     - name: Set up MSVC
       uses: ilammy/msvc-dev-cmd@v1
 
+    - name: Install OpenCL
+      run: vcpkg.exe --triplet=${{ matrix.config.arch }}-windows install opencl
+
     - name: Run CMake
       run: |
         mkdir ${{env.RELEASE_NAME}}


### PR DESCRIPTION
This way we can automatically make Linux, macOS and Windows release builds using Github Actions CI instead having to rely on local manual Linux builds and separate AppVeyor Windows builds.

Test release was made here:
https://github.com/CNugteren/CLBlast/actions/runs/5001623492/jobs/8960540379