### PR TITLE
Github Actions Windows builds with tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,12 +80,14 @@ jobs:
         cd openblas
         C:\msys64\usr\bin\wget.exe https://github.com/xianyi/OpenBLAS/releases/download/v0.3.23/OpenBLAS-0.3.23-x64.zip
         7z x OpenBLAS-0.3.23-x64.zip
+        pwd
+        ls
 
     - name: Install OpenCL
       run: vcpkg.exe --triplet=${{ matrix.config.arch }}-windows install opencl
 
     - name: Run CMake
-      run: cmake -S . -B build -DTESTS=ON -DCLIENTS=ON -DSAMPLES=ON -DOPENCL_ROOT=C:\vcpkg\packages\opencl_x64-windows -DCBLAS_ROOT=${GITHUB_WORKSPACE}\openblas
+      run: cmake -S . -B build -DTESTS=ON -DCLIENTS=ON -DSAMPLES=ON -DOPENCL_ROOT=C:\vcpkg\packages\opencl_x64-windows -DCBLAS_ROOT=${{ github.workspace }}\openblas
 
     - name: Compile the code
       run: cmake --build build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,14 +74,18 @@ jobs:
     - name: Set up MSVC
       uses: ilammy/msvc-dev-cmd@v1
 
-    - name: Install MKL
-      run: vcpkg.exe --triplet=${{ matrix.config.arch }}-windows install intel-mkl
+    - name: Install OpenBLAS
+      run: |
+        mkdir openblas
+        cd openblas
+        C:\msys64\usr\bin\wget.exe https://github.com/xianyi/OpenBLAS/releases/download/v0.3.23/OpenBLAS-0.3.23-x64.zip
+        7z x OpenBLAS-0.3.23-x64.zip
 
     - name: Install OpenCL
       run: vcpkg.exe --triplet=${{ matrix.config.arch }}-windows install opencl
 
     - name: Run CMake
-      run: cmake -S . -B build -DTESTS=ON -DCLIENTS=ON -DSAMPLES=ON -DOPENCL_ROOT=C:/vcpkg/packages/opencl_x64-windows -DMKL_ROOT=C:/vcpkg/packages/intel-mkl_x64-windows
+      run: cmake -S . -B build -DTESTS=ON -DCLIENTS=ON -DSAMPLES=ON -DOPENCL_ROOT=C:\vcpkg\packages\opencl_x64-windows -DCBLAS_ROOT=${GITHUB_WORKSPACE}\openblas
 
     - name: Compile the code
       run: cmake --build build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,14 +74,14 @@ jobs:
     - name: Set up MSVC
       uses: ilammy/msvc-dev-cmd@v1
 
-    - name: Install OpenBLAS
-      run: vcpkg.exe --triplet=${{ matrix.config.arch }}-windows install openblas
+    - name: Install MKL
+      run: vcpkg.exe --triplet=${{ matrix.config.arch }}-windows install intel-mkl
 
     - name: Install OpenCL
       run: vcpkg.exe --triplet=${{ matrix.config.arch }}-windows install opencl
 
     - name: Run CMake
-      run: cmake -S . -B build -DTESTS=ON -DCLIENTS=ON -DSAMPLES=ON -DOPENCL_ROOT=C:/vcpkg/packages/opencl_x64-windows -DCBLAS_ROOT=C:/vcpkg/packages/openblas_x64-windows
+      run: cmake -S . -B build -DTESTS=ON -DCLIENTS=ON -DSAMPLES=ON -DOPENCL_ROOT=C:/vcpkg/packages/opencl_x64-windows -DMKL_ROOT=C:/vcpkg/packages/intel-mkl_x64-windows
 
     - name: Compile the code
       run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ set(clblast_VERSION_PATCH 3)
 set(clblast_VERSION "${clblast_VERSION_MAJOR}.${clblast_VERSION_MINOR}.${clblast_VERSION_PATCH}")
 set(clblast_SOVERSION ${clblast_VERSION_MAJOR})
 
+# Policies
+cmake_policy(SET CMP0074 NEW)  # to make -DCBLAS_ROOT= work with newer CMake versions as well
+
 # Options and their default values
 option(BUILD_SHARED_LIBS "Build a shared (ON) or static library (OFF)" ON)
 option(SAMPLES "Enable compilation of the examples" OFF)

--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -48,11 +48,11 @@ mark_as_advanced(CBLAS_INCLUDE_DIRS)
 
 # Finds the library
 find_library(CBLAS_LIBRARIES
-  NAMES cblas blas blis openblas accelerate
+  NAMES cblas blas blis openblas libopenblas accelerate
   HINTS ${CBLAS_HINTS}
   PATH_SUFFIXES
-    lib lib64 lib/x86_64 lib/x64 lib/x86 lib/Win32 lib/import lib64/import
-    openblas/lib blis/lib lib/atlas-base
+    lib lib64 bin lib/x86_64 lib/x64 lib/x86 lib/Win32 lib/import lib64/import
+    openblas/bin openblas/lib blis/lib lib/atlas-base
   PATHS ${CBLAS_PATHS}
   DOC "Netlib BLAS library"
 )


### PR DESCRIPTION
Previously the Windows CI on Github Actions would not build the tests because no BLAS could be found. This is an attempt to solve that:
* Set CMake CMP0074 policy
* ~~Use MKL instead of OpenBLAS~~
* Use pre-downloade OpenBLAS instead