### PR TITLE
Fix issues in Windows release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,16 +79,16 @@ jobs:
 
     - name: Run CMake
       run: |
-        mkdir ${{env.RELEASE_NAME}}
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=${{env.RELEASE_NAME}} -DOPENCL_ROOT=C:/vcpkg/packages/opencl_x64-windows
+        mkdir clblast_release_dir
+        cmake -S . -B build -DTESTS=OFF -DCLIENTS=OFF -DSAMPLES=ON -DCMAKE_INSTALL_PREFIX=clblast_release_dir -DOPENCL_ROOT=C:/vcpkg/packages/opencl_x64-windows
 
     - name: Compile the code
-      run: cmake --build build
+      run: cmake --build build --config Release
 
     - name: Package the code
       run: |
         cmake --build build --target install
-        7z a -r ${{env.RELEASE_NAME}}.7z ${{env.RELEASE_NAME}}
+        7z a -r ${{env.RELEASE_NAME}}.7z clblast_release_dir
 
     - name: Upload the release
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
This fixes some issues seen in https://github.com/CNugteren/CLBlast/actions/runs/5039209358/jobs/9037203184 for Windows releases:
* The folder name with dots did not work, e.g. "clblast-1.6.0" created a folder named "clblast-1". Therefore the final .7z was empty.
* The build was done in debug mode instead of release mode, see https://stackoverflow.com/questions/19024259/how-to-change-the-build-type-to-release-mode-in-cmake

Fixes tested to work here: https://github.com/CNugteren/CLBlast/actions/runs/5049126014