### PR TITLE
Fix a multithreading bug related to storing objects in the cache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Development version (next version)
 - Fix pointer error in pyclblast on ARM
+- Fix a multithreading bug related to storing objects in the cache
 - Added tuned parameters for many devices (see doc/tuning.md)
 
 Version 1.6.0


### PR DESCRIPTION
See https://github.com/CNugteren/CLBlast/issues/486 for more details.

This closes https://github.com/CNugteren/CLBlast/issues/486.