### PR TITLE
Compress tar files in release.yml action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Package the code
       run: |
         cmake --build build --target install
-        tar -cvf ${{env.RELEASE_NAME}}.tar.gz ${{env.RELEASE_NAME}}
+        tar -cvzf ${{env.RELEASE_NAME}}.tar.gz ${{env.RELEASE_NAME}}
 
     - name: Upload the release
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fix: tar -cvf replaced with  tar -cvzf in release.yml
Files were just tar files even though they were labeled as .tar.gz

Referenced in issue #507 
https://github.com/CNugteren/CLBlast/issues/507

[As an aside it is possible for github action to create a release automatically using action-gh-release. Here's how I use it - ]
      - name: Create github release
        uses: softprops/action-gh-release@v1
        with:
          fail_on_unmatched_files: True
          tag_name: ${{ env.VERSION }}
          name: ${{ env.VERSION }}
          body_path: ./release.body.txt
          files: |
            ./artifacts/Saint_Helens.dmg/Saint_Helens.dmg
            ./artifacts/Saint_Helens_install.exe/Saint_Helens_install.exe
            ./repo/LICENSE
            ./repo/README.md

More details in 
https://github.com/angrave/shrinkwrap-python/blob/main/.github/workflows/shrinkwrap.yml
