### PR TITLE
Increased Tuner Safety

### DIFF
--- a/src/tuning/tuning.cpp
+++ b/src/tuning/tuning.cpp
@@ -266,6 +266,12 @@ void Tuner(int argc, char* argv[], const int V, GetTunerDefaultsFunc GetTunerDef
   const TunerSettings settings = GetTunerSettings(V, args);
 
   // Tests validity of the given arguments
+  if (args.extra_threads < 0) {
+    printf("Tuners cannot run without threads or negative threads. Provided %i threads. Exiting...\n",
+           args.extra_threads);
+    return;
+  }
+
   TestValidArguments(V, args);
 
   // Initializes OpenCL

--- a/src/utilities/utilities.hpp
+++ b/src/utilities/utilities.hpp
@@ -266,7 +266,7 @@ struct Arguments {
   // Common arguments
   size_t platform_id = 0;
   size_t device_id = 0;
-  size_t extra_threads = 1;
+  int extra_threads = 1;
   Precision precision = Precision::kSingle;
   bool print_help = false;
   bool silent = false;


### PR DESCRIPTION
Ensures the user does not pass too little of a value to the tuners leading to undefined behavior. This will print the error message and return.