### PR TITLE
Fixed Formatting Of Database Script

### DIFF
--- a/scripts/database/database/clblast.py
+++ b/scripts/database/database/clblast.py
@@ -92,7 +92,7 @@ def get_cpp_device_vendor(vendor, device_type):
 
 def get_cpp_family_includes(family, precisions):
     result = "\n"
-    result += "#include \"database/kernels/%s/%s.hpp\"\n" % (family, family)
+    result += "#include \"database/kernels/%s/%s.hpp\"\n\n" % (family, family)
     for precision in precisions:
         result += "#include \"database/kernels/%s/%s_%s.hpp\"\n" % (family, family, precision)
     return result


### PR DESCRIPTION
This makes it so that the script used to update the database with new tuning results follows Clang Format on the .cpp file. Now there is no need to manually go threw and format after adding new tuning results.