### PR TITLE
Resolves False Clang Tidy Checks Which Failed

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,5 @@
-Checks: "performance-*"
+Checks: "performance-* -performance-enum-size"
+
+CheckOptions:
+  - key: performance-unnecessary-value-param.AllowedTypes
+    value: std::shared_ptr


### PR DESCRIPTION
This removes [performance-enum-size] and makes it so that std::shared_ptr is not marked to be passed as reference.